### PR TITLE
Add kilometers and hours to technical info

### DIFF
--- a/components/assets/asset-edit-form.tsx
+++ b/components/assets/asset-edit-form.tsx
@@ -136,6 +136,16 @@ const formSchema = z.object({
     .refine((val) => !isNaN(Number(val)) && Number(val) >= 0, { 
       message: "Las horas actuales deben ser un número válido mayor o igual a 0" 
     }),
+  initialKilometers: z.string()
+    .optional()
+    .refine((val) => !val || (!isNaN(Number(val)) && Number(val) >= 0), { 
+      message: "Los kilómetros iniciales deben ser un número válido mayor o igual a 0" 
+    }),
+  currentKilometers: z.string()
+    .optional()
+    .refine((val) => !val || (!isNaN(Number(val)) && Number(val) >= 0), { 
+      message: "Los kilómetros actuales deben ser un número válido mayor o igual a 0" 
+    }),
   status: z.string().min(1, "El estado es requerido"),
   notes: z.string().optional(),
   warrantyExpiration: z.date({
@@ -229,6 +239,8 @@ export function AssetEditForm({ assetId }: AssetEditFormProps) {
       installationDate: undefined,
       initialHours: "0",
       currentHours: "0",
+      initialKilometers: "",
+      currentKilometers: "",
       status: "operational",
       notes: "",
       warrantyExpiration: undefined,
@@ -252,6 +264,8 @@ export function AssetEditForm({ assetId }: AssetEditFormProps) {
       installationDate: "Fecha de Instalación",
       initialHours: "Horas Iniciales",
       currentHours: "Horas Actuales",
+      initialKilometers: "Kilómetros Iniciales",
+      currentKilometers: "Kilómetros Actuales",
       status: "Estado",
       notes: "Notas",
       warrantyExpiration: "Vencimiento de Garantía",
@@ -306,7 +320,7 @@ export function AssetEditForm({ assetId }: AssetEditFormProps) {
       tabErrors.general = true
     }
 
-    if (errors.initialHours || errors.currentHours || errors.registrationInfo) {
+    if (errors.initialHours || errors.currentHours || errors.initialKilometers || errors.currentKilometers || errors.registrationInfo) {
       tabErrors.technical = true
     }
 
@@ -350,6 +364,8 @@ export function AssetEditForm({ assetId }: AssetEditFormProps) {
             installationDate: asset.installation_date ? new Date(asset.installation_date) : undefined,
             initialHours: (asset.initial_hours || 0).toString(),
             currentHours: (asset.current_hours || 0).toString(),
+            initialKilometers: asset.initial_kilometers ? asset.initial_kilometers.toString() : "",
+            currentKilometers: asset.current_kilometers ? asset.current_kilometers.toString() : "",
             status: asset.status || "operational",
             notes: asset.notes || "",
             warrantyExpiration: asset.warranty_expiration ? new Date(asset.warranty_expiration) : undefined,
@@ -934,6 +950,8 @@ export function AssetEditForm({ assetId }: AssetEditFormProps) {
         warranty_expiration: data.warrantyExpiration?.toISOString(),
         initial_hours: Number(data.initialHours),
         current_hours: Number(data.currentHours),
+        initial_kilometers: data.initialKilometers ? Number(data.initialKilometers) : null,
+        current_kilometers: data.currentKilometers ? Number(data.currentKilometers) : null,
         is_new: data.isNew,
         notes: data.notes,
         purchase_cost: data.purchaseCost || null,

--- a/components/assets/tabs/technical-info-tab.tsx
+++ b/components/assets/tabs/technical-info-tab.tsx
@@ -24,6 +24,8 @@ interface FormValues {
   installationDate?: Date
   initialHours: string
   currentHours: string
+  initialKilometers?: string
+  currentKilometers?: string
   status: string
   notes?: string
   warrantyExpiration?: Date
@@ -98,6 +100,38 @@ export function TechnicalInfoTab({
                   <Input type="number" min="0" {...field} />
                 </FormControl>
                 <FormDescription>Horas actuales de operación del equipo</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FormField
+            control={control}
+            name="initialKilometers"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Kilómetros Iniciales de Operación</FormLabel>
+                <FormControl>
+                  <Input type="number" min="0" {...field} />
+                </FormControl>
+                <FormDescription>Kilómetros de operación al momento de la adquisición</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={control}
+            name="currentKilometers"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Kilómetros Actuales de Operación</FormLabel>
+                <FormControl>
+                  <Input type="number" min="0" {...field} />
+                </FormControl>
+                <FormDescription>Kilómetros actuales de operación del equipo</FormDescription>
                 <FormMessage />
               </FormItem>
             )}


### PR DESCRIPTION
Add kilometers input fields to the asset technical information tab to allow users to track both hours and kilometers.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d657457-71ff-473c-b034-753de96b3c90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0d657457-71ff-473c-b034-753de96b3c90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

