### PR TITLE
Claude/deduplication dialog system 011 c uzx kq ks89659ckz fr dej

### DIFF
--- a/app/api/checklists/auto-create-pending-work-orders/route.ts
+++ b/app/api/checklists/auto-create-pending-work-orders/route.ts
@@ -3,195 +3,43 @@ import { NextResponse } from 'next/server'
 
 /**
  * Auto-create work orders for pending issues older than 1 hour
- * This endpoint should be called periodically by a cron job
  *
- * Setup instructions:
- * 1. Use Vercel Cron Jobs (add to vercel.json):
- *    {
- *      "crons": [{
- *        "path": "/api/checklists/auto-create-pending-work-orders",
- *        "schedule": "0 * * * *"  // Run every hour
- *      }]
- *    }
+ * This endpoint calls the Supabase database function that handles auto-creation.
+ * The actual cron job runs in the database using pg_cron (see migration file).
  *
- * 2. Or use an external cron service like cron-job.org to call this endpoint every hour
- * 3. Or call it from your monitoring dashboard periodically
+ * This endpoint can be used for:
+ * 1. Manual triggering from admin dashboard
+ * 2. Monitoring/testing the auto-creation system
+ * 3. Backup trigger if database cron fails
  */
 
 export async function GET() {
   try {
     const supabase = await createClient()
 
-    console.log('🔄 Starting auto-create check for pending work orders...')
+    console.log('🔄 Triggering auto-create for pending work orders...')
 
-    // Use raw SQL to get checklists with issues but NO work orders
-    const { data: unresolvedIssues, error } = await supabase
-      .rpc('get_truly_unresolved_checklist_issues')
+    // Call the database function that handles all the logic
+    const { data, error } = await supabase
+      .rpc('auto_create_pending_work_orders')
 
     if (error) {
-      console.error('Error fetching unresolved issues:', error)
+      console.error('Error calling auto-create function:', error)
       return NextResponse.json(
-        { error: 'Error al obtener problemas no resueltos' },
+        {
+          error: 'Error al ejecutar auto-creación',
+          details: error.message
+        },
         { status: 500 }
       )
     }
 
-    if (!unresolvedIssues || unresolvedIssues.length === 0) {
-      console.log('✅ No unresolved issues found')
-      return NextResponse.json({
-        success: true,
-        message: 'No unresolved issues to process',
-        auto_created_count: 0
-      })
-    }
+    console.log('✅ Auto-create completed:', data)
 
-    // Fetch completed checklists to get section_type information
-    const checklistIds = [...new Set(unresolvedIssues.map((issue: any) => issue.checklist_id))]
-    const { data: completedChecklists } = await supabase
-      .from('completed_checklists')
-      .select('id, completed_items, completion_date')
-      .in('id', checklistIds)
-
-    // Create a map of checklist_id -> data for quick lookup
-    const checklistDataMap = new Map<string, any>()
-    if (completedChecklists) {
-      for (const checklist of completedChecklists) {
-        checklistDataMap.set(checklist.id, checklist)
-      }
-    }
-
-    // Group issues by checklist and format for processing
-    const issuesByChecklist = new Map<string, any>()
-
-    for (const issue of unresolvedIssues) {
-      const checklistId = issue.checklist_id
-      const checklistData = checklistDataMap.get(checklistId)
-
-      if (!checklistData) continue
-
-      // Get section_type from completed_items
-      const completedItems = checklistData.completed_items || []
-      const completedItem = completedItems.find((item: any) => item.item_id === issue.item_id)
-      const sectionType = completedItem?.section_type || 'maintenance'
-      const sectionTitle = completedItem?.section_title || 'Problema detectado'
-
-      // Skip cleanliness and security sections
-      if (sectionType === 'cleanliness_bonus' || sectionType === 'security_talk') {
-        continue
-      }
-
-      if (!issuesByChecklist.has(checklistId)) {
-        issuesByChecklist.set(checklistId, {
-          checklistId: checklistId,
-          assetId: issue.asset_uuid,
-          assetName: issue.asset_name,
-          completionDate: checklistData.completion_date,
-          issues: [],
-          timestamp: new Date(checklistData.completion_date).getTime()
-        })
-      }
-
-      const groupedIssue = issuesByChecklist.get(checklistId)!
-      groupedIssue.issues.push({
-        id: issue.item_id,
-        description: issue.description,
-        notes: issue.notes || '',
-        photo: issue.photo_url,
-        status: issue.status as "flag" | "fail",
-        sectionTitle: sectionTitle,
-        sectionType: sectionType
-      })
-    }
-
-    const formattedIssues = Array.from(issuesByChecklist.values())
-
-    // Auto-create work orders for issues older than 1 hour
-    const ONE_HOUR_MS = 60 * 60 * 1000
-    const now = Date.now()
-    const autoCreatedChecklistIds: string[] = []
-    const errors: string[] = []
-
-    for (const issueGroup of formattedIssues) {
-      const issueAge = now - issueGroup.timestamp
-
-      if (issueAge > ONE_HOUR_MS) {
-        console.log(`🔄 Auto-creating work orders for checklist ${issueGroup.checklistId} (${Math.round(issueAge / 1000 / 60)} minutes old)`)
-
-        try {
-          // Prepare items with issues
-          const itemsWithIssues = issueGroup.issues.map((item: any) => ({
-            id: item.id,
-            description: item.description,
-            notes: item.notes,
-            photo_url: item.photo,
-            status: item.status,
-            sectionTitle: item.sectionTitle,
-            sectionType: item.sectionType
-          }))
-
-          // Determine priorities based on status (fail = high, flag = medium)
-          const priorities = itemsWithIssues.map((item: any) =>
-            item.status === 'fail' ? 'Alta' : 'Media'
-          )
-
-          // Create work orders with auto-consolidation enabled (all set to 'consolidate')
-          const consolidationChoices = itemsWithIssues.reduce((acc: any, item: any) => {
-            acc[item.id] = 'consolidate'
-            return acc
-          }, {})
-
-          // Import and call the work order creation logic directly
-          const workOrderModule = await import('../generate-corrective-work-order-enhanced/route')
-
-          // Create a mock request for the work order creation
-          const workOrderBody = {
-            checklist_id: issueGroup.checklistId,
-            asset_id: issueGroup.assetId,
-            items_with_issues: itemsWithIssues,
-            priorities,
-            consolidation_choices: consolidationChoices,
-            auto_created: true
-          }
-
-          const mockRequest = new Request('http://localhost:3000/api/checklists/generate-corrective-work-order-enhanced', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(workOrderBody)
-          })
-
-          const workOrderResponse = await workOrderModule.POST(mockRequest as any)
-
-          if (workOrderResponse.ok) {
-            console.log(`✅ Auto-created work orders for checklist ${issueGroup.checklistId}`)
-            autoCreatedChecklistIds.push(issueGroup.checklistId)
-          } else {
-            const errorText = await workOrderResponse.text()
-            const errorMsg = `Failed to auto-create for ${issueGroup.checklistId}: ${errorText}`
-            console.error(`❌ ${errorMsg}`)
-            errors.push(errorMsg)
-          }
-        } catch (error) {
-          const errorMsg = `Error auto-creating for ${issueGroup.checklistId}: ${error}`
-          console.error(`❌ ${errorMsg}`)
-          errors.push(errorMsg)
-        }
-      }
-    }
-
-    const responseData = {
+    return NextResponse.json({
       success: true,
-      message: `Processed ${formattedIssues.length} pending issue groups`,
-      auto_created_count: autoCreatedChecklistIds.length,
-      auto_created_checklist_ids: autoCreatedChecklistIds,
-      pending_count: formattedIssues.length - autoCreatedChecklistIds.length,
-      errors: errors.length > 0 ? errors : undefined
-    }
-
-    console.log('✅ Auto-create check completed:', responseData)
-
-    return NextResponse.json(responseData)
+      ...data
+    })
 
   } catch (error: any) {
     console.error('Error in auto-create endpoint:', error)
@@ -202,7 +50,7 @@ export async function GET() {
   }
 }
 
-// Also support POST for more secure cron job calls
+// Also support POST for more secure manual triggers
 export async function POST() {
   return GET()
 }

--- a/docs/AUTO_CREATE_WORK_ORDERS_SETUP.md
+++ b/docs/AUTO_CREATE_WORK_ORDERS_SETUP.md
@@ -1,0 +1,313 @@
+# Auto-Create Work Orders Setup Guide
+
+This system automatically creates work orders for checklist issues that remain unprocessed for more than 1 hour.
+
+## Overview
+
+The auto-creation system uses a **Supabase database function** with **pg_cron** to automatically process pending issues every hour. This approach is more reliable than API-based cron jobs because:
+
+- ✅ Runs directly in the database (no cold starts)
+- ✅ More efficient (no HTTP overhead)
+- ✅ Platform independent (works with any hosting)
+- ✅ Better for database operations
+- ✅ Automatic logging and monitoring
+
+## Architecture
+
+```
+Checklist Completion
+        ↓
+[Issues Created in DB]
+        ↓
+[Wait 1 hour] ← User has option to create manually
+        ↓
+[pg_cron triggers hourly]
+        ↓
+[auto_create_pending_work_orders() function]
+        ↓
+[Work Orders Created Automatically]
+```
+
+## Setup Instructions
+
+### 1. Run the Migration
+
+Execute the SQL migration in Supabase SQL Editor:
+
+```bash
+# The migration file is located at:
+migrations/sql/20250114_auto_create_pending_work_orders.sql
+```
+
+**Important:** Run this with elevated permissions (service_role) because it:
+- Creates the `auto_create_pending_work_orders()` function
+- Sets up the pg_cron job
+- Creates the `auto_create_logs` table for monitoring
+
+### 2. Verify the Cron Job
+
+After running the migration, verify the cron job was created:
+
+```sql
+SELECT * FROM cron.job WHERE jobname = 'auto-create-pending-work-orders';
+```
+
+You should see:
+- **jobname:** `auto-create-pending-work-orders`
+- **schedule:** `0 * * * *` (every hour)
+- **command:** `SELECT auto_create_pending_work_orders_with_logging()`
+
+### 3. Enable pg_cron Extension (if not already enabled)
+
+In Supabase Dashboard:
+1. Go to **Database** → **Extensions**
+2. Search for `pg_cron`
+3. Enable it
+
+Or run in SQL Editor:
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+```
+
+### 4. Grant Necessary Permissions
+
+The migration handles this, but verify:
+
+```sql
+GRANT EXECUTE ON FUNCTION auto_create_pending_work_orders() TO service_role;
+GRANT EXECUTE ON FUNCTION auto_create_pending_work_orders_with_logging() TO service_role;
+```
+
+## How It Works
+
+### 1. Automatic Detection
+
+The function runs every hour and:
+- Finds all `checklist_issues` that are `resolved = false`
+- Checks if the checklist's `completion_date` is > 1 hour ago
+- Excludes cleanliness and security section items
+- Skips checklists that already have work orders
+
+### 2. Smart Work Order Creation
+
+For each pending issue:
+- **Priority Assignment:** `fail` status → Alta, `flag` status → Media
+- **Consolidation:** Automatically consolidates with similar existing work orders using fingerprinting
+- **New Work Orders:** Creates new work orders when no similar issue exists
+- **Marking as Resolved:** Updates `checklist_issues.resolved = true`
+- **Incident History:** Logs all actions in `incident_history`
+
+### 3. Logging
+
+Every run is logged to `auto_create_logs` table:
+```sql
+SELECT * FROM auto_create_logs ORDER BY run_at DESC LIMIT 10;
+```
+
+Fields:
+- `run_at`: Timestamp of execution
+- `result`: JSON with created_count, checklist_ids, etc.
+- `success`: Boolean indicating if it succeeded
+- `error`: Error message if failed
+
+## Manual Triggering
+
+### Via API Endpoint
+
+Call the endpoint manually for testing or backup:
+
+```bash
+# GET request
+curl https://your-domain.com/api/checklists/auto-create-pending-work-orders
+
+# Or use in browser/admin dashboard
+```
+
+### Via SQL
+
+Run directly in Supabase SQL Editor:
+
+```sql
+SELECT auto_create_pending_work_orders();
+```
+
+This returns a JSON object:
+```json
+{
+  "success": true,
+  "created_count": 3,
+  "error_count": 0,
+  "checklist_ids": ["abc-123", "def-456", "ghi-789"],
+  "processed_at": "2025-01-14T10:00:00Z"
+}
+```
+
+## Monitoring
+
+### Check Recent Runs
+
+```sql
+SELECT
+  run_at,
+  result->>'created_count' as created,
+  result->>'error_count' as errors,
+  success
+FROM auto_create_logs
+ORDER BY run_at DESC
+LIMIT 10;
+```
+
+### Check Pending Issues
+
+See what will be auto-created in the next run:
+
+```sql
+SELECT
+  cc.id as checklist_id,
+  cc.completion_date,
+  a.name as asset_name,
+  COUNT(ci.id) as issue_count,
+  NOW() - cc.completion_date as age
+FROM checklist_issues ci
+JOIN completed_checklists cc ON ci.checklist_id = cc.id
+JOIN assets a ON cc.asset_id = a.id
+WHERE ci.resolved = false
+  AND cc.completion_date < NOW() - INTERVAL '1 hour'
+  AND NOT EXISTS (
+    SELECT 1 FROM work_orders wo
+    WHERE wo.checklist_id = ci.checklist_id
+  )
+GROUP BY cc.id, cc.completion_date, a.name
+ORDER BY cc.completion_date ASC;
+```
+
+### View Auto-Created Work Orders
+
+```sql
+SELECT
+  wo.work_order_id,
+  wo.description,
+  wo.priority,
+  wo.status,
+  wo.created_at,
+  a.name as asset_name
+FROM work_orders wo
+JOIN assets a ON wo.asset_id = a.id
+WHERE wo.description LIKE '[AUTO-CREADO]%'
+ORDER BY wo.created_at DESC
+LIMIT 20;
+```
+
+## Troubleshooting
+
+### Cron Job Not Running
+
+1. Check if pg_cron is enabled:
+```sql
+SELECT * FROM pg_extension WHERE extname = 'pg_cron';
+```
+
+2. Check cron job status:
+```sql
+SELECT * FROM cron.job WHERE jobname = 'auto-create-pending-work-orders';
+```
+
+3. Check for errors in logs:
+```sql
+SELECT * FROM auto_create_logs WHERE success = false ORDER BY run_at DESC;
+```
+
+### Function Errors
+
+View detailed logs:
+```sql
+SELECT
+  run_at,
+  result,
+  error
+FROM auto_create_logs
+WHERE success = false
+ORDER BY run_at DESC;
+```
+
+### Issues Not Being Auto-Created
+
+Possible reasons:
+1. Issue is less than 1 hour old
+2. Work order already exists for that checklist
+3. Issue is from cleanliness or security section
+4. Database function has an error (check `auto_create_logs`)
+
+Test manually:
+```sql
+SELECT auto_create_pending_work_orders();
+```
+
+## Configuration
+
+### Change Schedule
+
+To change the cron schedule (e.g., every 30 minutes):
+
+```sql
+SELECT cron.unschedule('auto-create-pending-work-orders');
+SELECT cron.schedule(
+  'auto-create-pending-work-orders',
+  '*/30 * * * *',  -- Every 30 minutes
+  $$SELECT auto_create_pending_work_orders_with_logging()$$
+);
+```
+
+### Change Time Threshold
+
+To change from 1 hour to 2 hours, edit the function:
+
+```sql
+CREATE OR REPLACE FUNCTION auto_create_pending_work_orders()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  -- ... (other declarations)
+  v_one_hour_ago timestamp;
+BEGIN
+  -- Change this line:
+  v_one_hour_ago := NOW() - INTERVAL '2 hours';  -- Was: '1 hour'
+
+  -- ... (rest of function)
+END;
+$$;
+```
+
+## Benefits
+
+### For Users
+- ✅ No lost issues - everything gets processed
+- ✅ Automatic prioritization based on severity
+- ✅ Smart consolidation reduces duplicate work orders
+- ✅ Works even if users close the dialog without creating
+
+### For System
+- ✅ Database-level reliability
+- ✅ Automatic logging and monitoring
+- ✅ No external dependencies
+- ✅ Efficient processing
+- ✅ Platform independent
+
+## Related Files
+
+- **Migration:** `migrations/sql/20250114_auto_create_pending_work_orders.sql`
+- **API Endpoint:** `app/api/checklists/auto-create-pending-work-orders/route.ts`
+- **Unresolved Issues API:** `app/api/checklists/unresolved-issues/route.ts`
+- **Client Component:** `components/checklists/unresolved-issues-tracker.tsx`
+
+## Support
+
+If you encounter issues:
+1. Check `auto_create_logs` table
+2. Run the function manually to test
+3. Verify pg_cron is running
+4. Check database permissions
+
+For questions, contact the development team.

--- a/migrations/sql/20250114_auto_create_pending_work_orders.sql
+++ b/migrations/sql/20250114_auto_create_pending_work_orders.sql
@@ -1,0 +1,299 @@
+-- Migration: Auto-create work orders for pending issues older than 1 hour
+-- This sets up a database function and pg_cron job to automatically create
+-- work orders for checklist issues that haven't been processed
+
+-- Enable pg_cron extension if not already enabled
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Function to auto-create work orders for pending issues
+CREATE OR REPLACE FUNCTION auto_create_pending_work_orders()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_result jsonb;
+  v_checklist record;
+  v_issue record;
+  v_work_order_id text;
+  v_asset_id uuid;
+  v_asset_name text;
+  v_priority text;
+  v_description text;
+  v_created_count integer := 0;
+  v_error_count integer := 0;
+  v_checklist_ids text[] := ARRAY[]::text[];
+  v_one_hour_ago timestamp;
+BEGIN
+  -- Calculate 1 hour ago timestamp
+  v_one_hour_ago := NOW() - INTERVAL '1 hour';
+
+  RAISE NOTICE 'Starting auto-create check for issues older than %', v_one_hour_ago;
+
+  -- Find all checklists with unresolved issues older than 1 hour
+  FOR v_checklist IN
+    SELECT DISTINCT
+      ci.checklist_id,
+      cc.asset_id,
+      cc.completion_date,
+      cc.completed_items,
+      a.name as asset_name,
+      a.asset_id as asset_code
+    FROM checklist_issues ci
+    JOIN completed_checklists cc ON ci.checklist_id = cc.id
+    JOIN assets a ON cc.asset_id = a.id
+    WHERE ci.resolved = false
+      AND cc.completion_date < v_one_hour_ago
+      AND NOT EXISTS (
+        -- Check if work orders already exist for this checklist
+        SELECT 1 FROM work_orders wo
+        WHERE wo.checklist_id = ci.checklist_id
+      )
+    ORDER BY cc.completion_date ASC
+  LOOP
+    BEGIN
+      RAISE NOTICE 'Processing checklist % (asset: %)', v_checklist.checklist_id, v_checklist.asset_name;
+
+      -- Get all unresolved issues for this checklist (excluding cleanliness and security)
+      FOR v_issue IN
+        SELECT
+          ci.id,
+          ci.item_id,
+          ci.description,
+          ci.notes,
+          ci.status,
+          ci.photo_url
+        FROM checklist_issues ci
+        WHERE ci.checklist_id = v_checklist.checklist_id
+          AND ci.resolved = false
+          -- Exclude cleanliness and security sections
+          AND NOT EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(v_checklist.completed_items) AS item
+            WHERE (item->>'item_id')::text = ci.item_id
+              AND (item->>'section_type')::text IN ('cleanliness_bonus', 'security_talk')
+          )
+      LOOP
+        -- Determine priority based on status
+        v_priority := CASE
+          WHEN v_issue.status = 'fail' THEN 'Alta'
+          ELSE 'Media'
+        END;
+
+        -- Build description
+        v_description := v_issue.description || E'\n\n' || COALESCE(v_issue.notes, '');
+
+        -- Generate unique work order ID
+        v_work_order_id := (SELECT generate_unique_work_order_id());
+
+        -- Check for similar existing open work orders using fingerprint
+        DECLARE
+          v_fingerprint text;
+          v_similar_wo_id text;
+        BEGIN
+          -- Generate fingerprint for this issue
+          v_fingerprint := (
+            SELECT generate_issue_fingerprint(
+              v_checklist.asset_id,
+              v_issue.description,
+              v_issue.status,
+              v_issue.notes
+            )
+          );
+
+          -- Find similar open work orders within 30 days
+          SELECT wo.work_order_id INTO v_similar_wo_id
+          FROM work_orders wo
+          WHERE wo.asset_id = v_checklist.asset_id
+            AND wo.status IN ('Pendiente', 'En Progreso', 'en_progreso', 'pendiente')
+            AND wo.fingerprint = v_fingerprint
+            AND wo.created_at > NOW() - INTERVAL '30 days'
+          ORDER BY wo.created_at DESC
+          LIMIT 1;
+
+          IF v_similar_wo_id IS NOT NULL THEN
+            -- Consolidate with existing work order
+            RAISE NOTICE 'Consolidating issue % with existing work order %', v_issue.id, v_similar_wo_id;
+
+            -- Update existing work order description
+            UPDATE work_orders
+            SET
+              description = description || E'\n\n--- Problema adicional (Auto-consolidado) ---\n' || v_description,
+              priority = CASE
+                WHEN v_priority = 'Alta' THEN 'Alta'  -- Escalate if new issue is high priority
+                ELSE priority
+              END,
+              updated_at = NOW()
+            WHERE work_order_id = v_similar_wo_id;
+
+            -- Link the issue to the existing work order
+            UPDATE checklist_issues
+            SET resolved = true
+            WHERE id = v_issue.id;
+
+            -- Add to incident history
+            INSERT INTO incident_history (
+              work_order_id,
+              status,
+              notes,
+              changed_by
+            ) VALUES (
+              v_similar_wo_id,
+              'En Progreso',
+              'Problema adicional consolidado automáticamente: ' || v_issue.description,
+              'system_auto_create'
+            );
+
+          ELSE
+            -- Create new work order
+            RAISE NOTICE 'Creating new work order % for issue %', v_work_order_id, v_issue.id;
+
+            INSERT INTO work_orders (
+              work_order_id,
+              asset_id,
+              description,
+              priority,
+              status,
+              type,
+              checklist_id,
+              fingerprint,
+              created_at,
+              updated_at
+            ) VALUES (
+              v_work_order_id,
+              v_checklist.asset_id,
+              '[AUTO-CREADO] ' || v_description,
+              v_priority,
+              'Pendiente',
+              'Correctivo',
+              v_checklist.checklist_id,
+              v_fingerprint,
+              NOW(),
+              NOW()
+            );
+
+            -- Mark issue as resolved
+            UPDATE checklist_issues
+            SET resolved = true
+            WHERE id = v_issue.id;
+
+            -- Create incident history entry
+            INSERT INTO incident_history (
+              work_order_id,
+              status,
+              notes,
+              changed_by
+            ) VALUES (
+              v_work_order_id,
+              'Pendiente',
+              'Orden de trabajo creada automáticamente después de 1 hora sin acción manual',
+              'system_auto_create'
+            );
+          END IF;
+
+        END;
+      END LOOP;
+
+      -- Track processed checklist
+      v_checklist_ids := array_append(v_checklist_ids, v_checklist.checklist_id);
+      v_created_count := v_created_count + 1;
+
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Error processing checklist %: %', v_checklist.checklist_id, SQLERRM;
+      v_error_count := v_error_count + 1;
+    END;
+  END LOOP;
+
+  -- Build result
+  v_result := jsonb_build_object(
+    'success', true,
+    'created_count', v_created_count,
+    'error_count', v_error_count,
+    'checklist_ids', v_checklist_ids,
+    'processed_at', NOW()
+  );
+
+  RAISE NOTICE 'Auto-create completed: % checklists processed, % errors', v_created_count, v_error_count;
+
+  RETURN v_result;
+END;
+$$;
+
+-- Grant execute permission to authenticated users
+GRANT EXECUTE ON FUNCTION auto_create_pending_work_orders() TO authenticated;
+GRANT EXECUTE ON FUNCTION auto_create_pending_work_orders() TO service_role;
+
+-- Create pg_cron job to run every hour
+-- Note: This requires the pg_cron extension and appropriate permissions
+-- Run this in the Supabase SQL Editor with elevated permissions
+
+-- First, unschedule any existing job with the same name
+SELECT cron.unschedule('auto-create-pending-work-orders');
+
+-- Schedule the job to run every hour at minute 0
+SELECT cron.schedule(
+  'auto-create-pending-work-orders',     -- Job name
+  '0 * * * *',                           -- Cron schedule: every hour
+  $$SELECT auto_create_pending_work_orders()$$  -- SQL command to execute
+);
+
+-- Verify the job was scheduled
+SELECT * FROM cron.job WHERE jobname = 'auto-create-pending-work-orders';
+
+-- Optional: Create a table to log auto-creation runs
+CREATE TABLE IF NOT EXISTS auto_create_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_at timestamp DEFAULT NOW(),
+  result jsonb,
+  success boolean,
+  error text
+);
+
+-- Add RLS policy
+ALTER TABLE auto_create_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow service role to manage auto_create_logs"
+  ON auto_create_logs
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Create a logging wrapper function
+CREATE OR REPLACE FUNCTION auto_create_pending_work_orders_with_logging()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_result jsonb;
+BEGIN
+  -- Call the main function
+  v_result := auto_create_pending_work_orders();
+
+  -- Log the result
+  INSERT INTO auto_create_logs (result, success)
+  VALUES (v_result, true);
+
+EXCEPTION WHEN OTHERS THEN
+  -- Log the error
+  INSERT INTO auto_create_logs (result, success, error)
+  VALUES (
+    jsonb_build_object('error', SQLERRM),
+    false,
+    SQLERRM
+  );
+END;
+$$;
+
+-- Update the cron job to use the logging wrapper
+SELECT cron.unschedule('auto-create-pending-work-orders');
+SELECT cron.schedule(
+  'auto-create-pending-work-orders',
+  '0 * * * *',
+  $$SELECT auto_create_pending_work_orders_with_logging()$$
+);
+
+-- Comment for documentation
+COMMENT ON FUNCTION auto_create_pending_work_orders() IS
+'Automatically creates work orders for checklist issues that are older than 1 hour and have not been processed. Excludes cleanliness and security section items. Consolidates with existing similar work orders when possible.';

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "crons": [
-    {
-      "path": "/api/checklists/auto-create-pending-work-orders",
-      "schedule": "0 * * * *"
-    }
-  ]
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/checklists/auto-create-pending-work-orders",
+      "schedule": "0 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
attempt to have the autocreation after 1 hour of the checklist incidents when pending

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a DB function + cron to auto-create work orders for >1h unresolved checklist issues, exposes a trigger endpoint, integrates into unresolved-issues API/UI, and documents setup.
> 
> - **Backend/API**
>   - Adds `GET/POST /api/checklists/auto-create-pending-work-orders` to trigger `auto_create_pending_work_orders`.
>   - Updates `app/api/checklists/unresolved-issues/route.ts` to invoke auto-creation, re-fetch issues if created, and return `auto_created_count`.
> - **Database/Migrations**
>   - Creates `auto_create_pending_work_orders()` with consolidation, priority assignment, resolution, and `incident_history` logging.
>   - Schedules hourly pg_cron job via `auto_create_pending_work_orders_with_logging()`; adds `auto_create_logs` table and RLS policy.
> - **Frontend**
>   - Simplifies `components/checklists/unresolved-issues-tracker.tsx`: removes client-side auto-create; fetches server-filtered issues and shows toast when `auto_created_count > 0`.
> - **Docs**
>   - Adds `docs/AUTO_CREATE_WORK_ORDERS_SETUP.md` detailing architecture, setup, monitoring, and configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff1ffc2147da278d733e702dd519fe1e79950a3c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->