### PR TITLE
feat(work-orders): Phase 1 UX redesign + role-based permissions

### DIFF
--- a/app/ordenes/page.tsx
+++ b/app/ordenes/page.tsx
@@ -1,12 +1,10 @@
 import type { Metadata } from "next"
 import { Suspense } from "react"
-import { Button } from "@/components/ui/button"
 import { DashboardHeader } from "@/components/dashboard/dashboard-header"
 import { DashboardShell } from "@/components/dashboard/dashboard-shell"
 import { WorkOrdersList } from "@/components/work-orders/work-orders-list"
+import { WorkOrderCreateButton } from "@/components/work-orders/work-order-create-button"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Plus } from "lucide-react"
-import Link from "next/link"
 
 export const metadata: Metadata = {
   title: "Órdenes de Trabajo | Sistema de Gestión de Mantenimiento",
@@ -21,12 +19,7 @@ export default function WorkOrdersPage() {
         text="Planificación, aprobación y asignación de trabajos"
         id="ordenes-header"
       >
-        <Button asChild>
-          <Link href="/ordenes/crear">
-            <Plus className="mr-2 h-4 w-4" />
-            Nueva OT
-          </Link>
-        </Button>
+        <WorkOrderCreateButton />
       </DashboardHeader>
       <Suspense fallback={
         <div className="space-y-4">

--- a/components/work-orders/use-delete-work-order.ts
+++ b/components/work-orders/use-delete-work-order.ts
@@ -1,0 +1,95 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { createClient } from "@/lib/supabase"
+import { useToast } from "@/hooks/use-toast"
+import { WorkOrderWithAsset } from "@/types"
+
+const cleanupModalState = (callback: () => void, delay: number = 100) => {
+  setTimeout(() => {
+    callback()
+    const modalOverlays = document.querySelectorAll(
+      "[data-radix-focus-guard], [data-radix-scroll-lock-wrapper]"
+    )
+    modalOverlays.forEach((overlay) => {
+      if (overlay.parentNode) {
+        overlay.parentNode.removeChild(overlay)
+      }
+    })
+    if (document.activeElement && document.activeElement !== document.body) {
+      (document.activeElement as HTMLElement).blur()
+    }
+    document.body.focus()
+    document.body.removeAttribute("aria-hidden")
+    document.body.style.removeProperty("pointer-events")
+  }, delay)
+}
+
+export interface UseDeleteWorkOrderOptions {
+  onDeleted?: (order: WorkOrderWithAsset) => void
+}
+
+export function useDeleteWorkOrder(options: UseDeleteWorkOrderOptions = {}) {
+  const { onDeleted } = options
+  const { toast } = useToast()
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [orderToDelete, setOrderToDelete] = useState<WorkOrderWithAsset | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const openDelete = useCallback((order: WorkOrderWithAsset) => {
+    setOrderToDelete(order)
+    setDeleteDialogOpen(true)
+  }, [])
+
+  const confirmDelete = useCallback(async () => {
+    if (!orderToDelete) return
+
+    setIsDeleting(true)
+    try {
+      const supabase = createClient()
+      const { error } = await supabase
+        .from("work_orders")
+        .delete()
+        .eq("id", orderToDelete.id)
+
+      if (error) {
+        console.error("Error al eliminar orden de trabajo:", error)
+        toast({
+          title: "Error",
+          description:
+            "No se pudo eliminar la orden de trabajo. Por favor, intente nuevamente.",
+          variant: "destructive",
+        })
+        setIsDeleting(false)
+      } else {
+        toast({
+          title: "Orden eliminada",
+          description: `La orden de trabajo ${orderToDelete.order_id} ha sido eliminada exitosamente.`,
+        })
+        onDeleted?.(orderToDelete)
+        setIsDeleting(false)
+        setDeleteDialogOpen(false)
+        cleanupModalState(() => {
+          setOrderToDelete(null)
+        }, 100)
+      }
+    } catch (error) {
+      console.error("Error al eliminar orden de trabajo:", error)
+      toast({
+        title: "Error",
+        description: "Ocurrió un error inesperado. Por favor, intente nuevamente.",
+        variant: "destructive",
+      })
+      setIsDeleting(false)
+    }
+  }, [orderToDelete, onDeleted, toast])
+
+  return {
+    openDelete,
+    orderToDelete,
+    deleteDialogOpen,
+    setDeleteDialogOpen,
+    confirmDelete,
+    isDeleting,
+  }
+}

--- a/components/work-orders/work-order-actions-menu.tsx
+++ b/components/work-orders/work-order-actions-menu.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  CheckCircle,
+  Edit,
+  Eye,
+  FileText,
+  MoreHorizontal,
+  ShoppingCart,
+  Trash,
+  Wrench,
+  AlertTriangle,
+  CalendarDays,
+  ListChecks,
+} from "lucide-react"
+import { WorkOrderWithAsset, WorkOrderStatus, MaintenanceType } from "@/types"
+
+export interface WorkOrderActionsMenuProps {
+  order: WorkOrderWithAsset
+  getPurchaseOrderStatus?: (poId: string | null) => string
+  onDeleteOrder: (order: WorkOrderWithAsset) => void
+  variant: "mobile" | "desktop"
+}
+
+export function WorkOrderActionsMenu({
+  order,
+  getPurchaseOrderStatus,
+  onDeleteOrder,
+  variant,
+}: WorkOrderActionsMenuProps) {
+  const isMobile = variant === "mobile"
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="h-8 w-8 p-0">
+          <span className="sr-only">Abrir menú</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Acciones</DropdownMenuLabel>
+        <DropdownMenuItem asChild>
+          <Link href={`/ordenes/${order.id}`}>
+            <Eye className="mr-2 h-4 w-4" />
+            <span>Ver Detalles</span>
+          </Link>
+        </DropdownMenuItem>
+        {!isMobile && (
+          <DropdownMenuItem asChild>
+            <Link href={`/servicios?workOrderId=${order.id}`}>
+              <FileText className="mr-2 h-4 w-4" />
+              <span>Ver Servicio</span>
+            </Link>
+          </DropdownMenuItem>
+        )}
+        {!isMobile && order.incident_id && order.asset_id && (
+          <DropdownMenuItem asChild>
+            <Link href={`/activos/${order.asset_id}/incidentes`}>
+              <AlertTriangle className="mr-2 h-4 w-4" />
+              <span>Incidente</span>
+            </Link>
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem asChild>
+          <Link href={`/ordenes/${order.id}/editar`}>
+            <Edit className="mr-2 h-4 w-4" />
+            <span>Editar OT</span>
+          </Link>
+        </DropdownMenuItem>
+        {!order.purchase_order_id && order.required_parts && !isMobile && (
+          <DropdownMenuItem asChild>
+            <Link href={`/ordenes/${order.id}/generar-oc`}>
+              <ShoppingCart className="mr-2 h-4 w-4" />
+              <span>Generar OC</span>
+            </Link>
+          </DropdownMenuItem>
+        )}
+        {order.purchase_order_id && (
+          <DropdownMenuItem asChild>
+            <Link href={`/compras/${order.purchase_order_id}`}>
+              <ShoppingCart className="mr-2 h-4 w-4" />
+              <span>Ver OC</span>
+            </Link>
+          </DropdownMenuItem>
+        )}
+        {!isMobile && (
+          <DropdownMenuItem asChild>
+            <a href={`/ordenes/${order.id}#checklist`}>
+              <ListChecks className="mr-2 h-4 w-4" />
+              <span>Ver Checklist</span>
+            </a>
+          </DropdownMenuItem>
+        )}
+        {order.status !== WorkOrderStatus.Completed && (
+          <DropdownMenuItem asChild>
+            <Link href={`/ordenes/${order.id}/completar`}>
+              <Wrench className="mr-2 h-4 w-4" />
+              <span>{isMobile ? "Completar OT" : "Registrar Mantenimiento"}</span>
+            </Link>
+          </DropdownMenuItem>
+        )}
+        {!isMobile && (
+          <>
+            <DropdownMenuItem asChild>
+              <Link href={`/ordenes/${order.id}/editar`}>
+                <CalendarDays className="mr-2 h-4 w-4" />
+                <span>Re-Programar</span>
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href={`/ordenes/${order.id}/completar`}>
+                <CheckCircle className="mr-2 h-4 w-4" />
+                <span>Cambiar Estado</span>
+              </Link>
+            </DropdownMenuItem>
+          </>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="text-red-600 hover:bg-red-50 hover:text-red-700"
+          onClick={() => onDeleteOrder(order)}
+        >
+          <Trash className="mr-2 h-4 w-4" />
+          <span>Eliminar OT</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/work-orders/work-order-actions-menu.tsx
+++ b/components/work-orders/work-order-actions-menu.tsx
@@ -30,6 +30,8 @@ export interface WorkOrderActionsMenuProps {
   getPurchaseOrderStatus?: (poId: string | null) => string
   onDeleteOrder: (order: WorkOrderWithAsset) => void
   variant: "mobile" | "desktop"
+  canEdit?: boolean
+  canDelete?: boolean
 }
 
 export function WorkOrderActionsMenu({
@@ -37,6 +39,8 @@ export function WorkOrderActionsMenu({
   getPurchaseOrderStatus,
   onDeleteOrder,
   variant,
+  canEdit = true,
+  canDelete = true,
 }: WorkOrderActionsMenuProps) {
   const isMobile = variant === "mobile"
 
@@ -72,13 +76,15 @@ export function WorkOrderActionsMenu({
             </Link>
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem asChild>
-          <Link href={`/ordenes/${order.id}/editar`}>
-            <Edit className="mr-2 h-4 w-4" />
-            <span>Editar OT</span>
-          </Link>
-        </DropdownMenuItem>
-        {!order.purchase_order_id && order.required_parts && !isMobile && (
+        {canEdit && (
+          <DropdownMenuItem asChild>
+            <Link href={`/ordenes/${order.id}/editar`}>
+              <Edit className="mr-2 h-4 w-4" />
+              <span>Editar OT</span>
+            </Link>
+          </DropdownMenuItem>
+        )}
+        {canEdit && !order.purchase_order_id && order.required_parts && !isMobile && (
           <DropdownMenuItem asChild>
             <Link href={`/ordenes/${order.id}/generar-oc`}>
               <ShoppingCart className="mr-2 h-4 w-4" />
@@ -102,7 +108,7 @@ export function WorkOrderActionsMenu({
             </a>
           </DropdownMenuItem>
         )}
-        {order.status !== WorkOrderStatus.Completed && (
+        {canEdit && order.status !== WorkOrderStatus.Completed && (
           <DropdownMenuItem asChild>
             <Link href={`/ordenes/${order.id}/completar`}>
               <Wrench className="mr-2 h-4 w-4" />
@@ -110,7 +116,7 @@ export function WorkOrderActionsMenu({
             </Link>
           </DropdownMenuItem>
         )}
-        {!isMobile && (
+        {canEdit && !isMobile && (
           <>
             <DropdownMenuItem asChild>
               <Link href={`/ordenes/${order.id}/editar`}>
@@ -126,14 +132,18 @@ export function WorkOrderActionsMenu({
             </DropdownMenuItem>
           </>
         )}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          className="text-red-600 hover:bg-red-50 hover:text-red-700"
-          onClick={() => onDeleteOrder(order)}
-        >
-          <Trash className="mr-2 h-4 w-4" />
-          <span>Eliminar OT</span>
-        </DropdownMenuItem>
+        {canDelete && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-red-600 hover:bg-red-50 hover:text-red-700"
+              onClick={() => onDeleteOrder(order)}
+            >
+              <Trash className="mr-2 h-4 w-4" />
+              <span>Eliminar OT</span>
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/components/work-orders/work-order-badges.ts
+++ b/components/work-orders/work-order-badges.ts
@@ -1,0 +1,115 @@
+import {
+  WorkOrderStatus,
+  MaintenanceType,
+  ServiceOrderPriority,
+  PurchaseOrderStatus,
+} from "@/types"
+
+export function getPriorityVariant(priority: string | null) {
+  switch (priority) {
+    case ServiceOrderPriority.Critical:
+      return "destructive"
+    case ServiceOrderPriority.High:
+      return "secondary"
+    default:
+      return "outline"
+  }
+}
+
+export function getStatusVariant(status: string | null) {
+  switch (status) {
+    case WorkOrderStatus.Completed:
+      return "default"
+    case WorkOrderStatus.InProgress:
+      return "secondary"
+    case WorkOrderStatus.Pending:
+    case WorkOrderStatus.Quoted:
+    case WorkOrderStatus.Approved:
+      return "outline"
+    default:
+      return "outline"
+  }
+}
+
+export function getTypeVariant(type: string | null) {
+  switch (type) {
+    case MaintenanceType.Preventive:
+      return "outline"
+    case MaintenanceType.Corrective:
+      return "destructive"
+    default:
+      return "secondary"
+  }
+}
+
+export function getPurchaseOrderStatusVariant(status: string) {
+  switch (status) {
+    case PurchaseOrderStatus.PendingApproval:
+    case "pending":
+    case "Pending":
+      return "outline"
+    case PurchaseOrderStatus.Approved:
+    case "approved":
+    case "Approved":
+      return "secondary"
+    case PurchaseOrderStatus.Validated:
+    case "ordered":
+    case "Ordered":
+      return "default"
+    case PurchaseOrderStatus.Received:
+    case "received":
+    case "Received":
+      return "default"
+    case PurchaseOrderStatus.Rejected:
+    case "rejected":
+    case "Rejected":
+      return "destructive"
+    default:
+      return "outline"
+  }
+}
+
+export function getPurchaseOrderStatusClass(status: string) {
+  switch (status) {
+    case PurchaseOrderStatus.PendingApproval:
+    case "pending":
+    case "Pending":
+      return "bg-yellow-50 text-yellow-800"
+    case PurchaseOrderStatus.Approved:
+    case "approved":
+    case "Approved":
+      return "bg-blue-50 text-blue-800"
+    case PurchaseOrderStatus.Validated:
+    case "ordered":
+    case "Ordered":
+      return "bg-indigo-50 text-indigo-800"
+    case PurchaseOrderStatus.Received:
+    case "received":
+    case "Received":
+      return "bg-green-100 text-green-800"
+    case PurchaseOrderStatus.Rejected:
+    case "rejected":
+    case "Rejected":
+      return "bg-red-50 text-red-800"
+    default:
+      return ""
+  }
+}
+
+export function formatDate(dateString: string | null): string {
+  if (!dateString) return "N/A"
+  try {
+    const date = new Date(dateString)
+    if (isNaN(date.getTime())) {
+      return dateString
+    }
+    return new Intl.DateTimeFormat("es-ES", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(date)
+  } catch (error) {
+    console.warn("Error formatting date:", dateString, error)
+    return dateString
+  }
+}

--- a/components/work-orders/work-order-badges.ts
+++ b/components/work-orders/work-order-badges.ts
@@ -5,6 +5,52 @@ import {
   PurchaseOrderStatus,
 } from "@/types"
 
+/** Tailwind classes for status dot (e.g. "bg-green-500") */
+export function getStatusDotClass(status: string | null): string {
+  switch (status) {
+    case WorkOrderStatus.Completed:
+      return "bg-green-500"
+    case WorkOrderStatus.InProgress:
+      return "bg-blue-500"
+    case WorkOrderStatus.Pending:
+    case WorkOrderStatus.Quoted:
+    case WorkOrderStatus.Approved:
+      return "bg-slate-400"
+    default:
+      return "bg-slate-400"
+  }
+}
+
+/** Tailwind classes for left border by status (e.g. "border-l-green-500") */
+export function getStatusBorderClass(status: string | null): string {
+  switch (status) {
+    case WorkOrderStatus.Completed:
+      return "border-l-green-500"
+    case WorkOrderStatus.InProgress:
+      return "border-l-blue-500"
+    case WorkOrderStatus.Pending:
+    case WorkOrderStatus.Quoted:
+    case WorkOrderStatus.Approved:
+      return "border-l-slate-400"
+    default:
+      return "border-l-slate-400"
+  }
+}
+
+/** Tailwind classes for priority dot/badge: Critical=red, High=orange, Medium=gray */
+export function getPriorityDotClass(priority: string | null): string {
+  switch (priority) {
+    case ServiceOrderPriority.Critical:
+      return "bg-red-500"
+    case ServiceOrderPriority.High:
+      return "bg-amber-500"
+    case ServiceOrderPriority.Medium:
+    case ServiceOrderPriority.Low:
+    default:
+      return "bg-slate-400"
+  }
+}
+
 export function getPriorityVariant(priority: string | null) {
   switch (priority) {
     case ServiceOrderPriority.Critical:
@@ -110,6 +156,28 @@ export function formatDate(dateString: string | null): string {
     }).format(date)
   } catch (error) {
     console.warn("Error formatting date:", dateString, error)
+    return dateString
+  }
+}
+
+/** Relative date for list UX: "Hoy", "Mañana", "Hace 3 días", or short absolute */
+export function formatDateRelative(dateString: string | null): string {
+  if (!dateString) return "—"
+  try {
+    const date = new Date(dateString)
+    date.setHours(0, 0, 0, 0)
+    if (isNaN(date.getTime())) return dateString
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const diffMs = date.getTime() - today.getTime()
+    const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24))
+    if (diffDays === 0) return "Hoy"
+    if (diffDays === 1) return "Mañana"
+    if (diffDays === -1) return "Ayer"
+    if (diffDays >= -6 && diffDays <= -2) return `Hace ${Math.abs(diffDays)} días`
+    if (diffDays >= 2 && diffDays <= 6) return `En ${diffDays} días`
+    return new Intl.DateTimeFormat("es-ES", { month: "short", day: "numeric" }).format(date)
+  } catch {
     return dateString
   }
 }

--- a/components/work-orders/work-order-card-mobile.tsx
+++ b/components/work-orders/work-order-card-mobile.tsx
@@ -1,12 +1,39 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Calendar, Package, ShoppingCart, User } from "lucide-react"
-import { WorkOrderWithAsset } from "@/types"
-import { getStatusVariant, getTypeVariant, getPriorityVariant, getPurchaseOrderStatusVariant, getPurchaseOrderStatusClass, formatDate } from "./work-order-badges"
-import { WorkOrderActionsMenu } from "./work-order-actions-menu"
+import { Button } from "@/components/ui/button"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import {
+  Calendar,
+  Edit,
+  Eye,
+  MoreHorizontal,
+  ShoppingCart,
+  Trash,
+  Wrench,
+} from "lucide-react"
+import { WorkOrderWithAsset, WorkOrderStatus } from "@/types"
+import {
+  getStatusVariant,
+  getStatusBorderClass,
+  getTypeVariant,
+  getPriorityVariant,
+  getPriorityDotClass,
+  getPurchaseOrderStatusVariant,
+  getPurchaseOrderStatusClass,
+  formatDateRelative,
+} from "./work-order-badges"
+import { cn } from "@/lib/utils"
 
 export interface WorkOrderCardMobileProps {
   order: WorkOrderWithAsset
@@ -25,57 +52,60 @@ export function WorkOrderCardMobile({
   canEdit = true,
   canDelete = true,
 }: WorkOrderCardMobileProps) {
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const techName = getTechnicianName(order.assigned_to)
+  const initials = techName !== "No asignado"
+    ? techName
+        .split(" ")
+        .map((n) => n[0])
+        .join("")
+        .slice(0, 2)
+        .toUpperCase()
+    : "—"
+
   return (
-    <Card className="w-full h-fit hover:shadow-md transition-shadow">
-      <CardHeader className="pb-3">
-        <div className="flex justify-between items-start">
-          <div className="space-y-1 flex-1 min-w-0">
-            <CardTitle className="text-lg font-semibold truncate">
-              {order.order_id}
+    <Card
+      className={cn(
+        "w-full overflow-hidden border-l-4 transition-shadow hover:shadow-md",
+        getStatusBorderClass(order.status)
+      )}
+    >
+      <CardHeader className="pb-2 pt-4 px-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <CardTitle className="text-lg font-semibold leading-tight truncate text-foreground">
+              {order.asset?.name || "N/A"}
             </CardTitle>
-            <p className="text-sm text-muted-foreground line-clamp-2">
-              {order.description}
+            {order.asset?.asset_id && (
+              <p className="text-xs text-muted-foreground mt-0.5">{order.asset.asset_id}</p>
+            )}
+            <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+              {order.order_id}
+              {order.description ? ` · ${order.description}` : ""}
             </p>
           </div>
-          <div className="flex items-center gap-2">
-            <Badge variant={getStatusVariant(order.status)} className="shrink-0">
+          <div className="flex items-center gap-2 shrink-0">
+            <Badge variant={getStatusVariant(order.status)} className="text-xs capitalize">
               {order.status || "Pendiente"}
             </Badge>
-            <WorkOrderActionsMenu
-              order={order}
-              getPurchaseOrderStatus={getPurchaseOrderStatus}
-              onDeleteOrder={onDeleteOrder}
-              variant="mobile"
-              canEdit={canEdit}
-              canDelete={canDelete}
-            />
+            <div className="flex items-center gap-1">
+              <span
+                className={cn("h-1.5 w-1.5 rounded-full", getPriorityDotClass(order.priority))}
+                aria-hidden
+              />
+              <Badge variant={getPriorityVariant(order.priority)} className="text-xs capitalize">
+                {order.priority || "Normal"}
+              </Badge>
+            </div>
           </div>
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4">
-        {/* Asset Info */}
-        <div className="flex items-center gap-2 text-sm">
-          <Package className="h-4 w-4 text-muted-foreground shrink-0" />
-          <div className="flex-1 min-w-0">
-            <p className="font-medium truncate">
-              {order.asset?.name || "N/A"}
-            </p>
-            {order.asset?.asset_id && (
-              <p className="text-xs text-muted-foreground">
-                ID: {order.asset.asset_id}
-              </p>
-            )}
-          </div>
-        </div>
-
-        {/* Type and Priority */}
-        <div className="flex gap-2 flex-wrap items-center">
+      <CardContent className="px-4 pb-4 space-y-4">
+        {/* Type + incident link */}
+        <div className="flex flex-wrap items-center gap-2">
           <Badge variant={getTypeVariant(order.type)} className="text-xs">
             {order.type || "N/A"}
-          </Badge>
-          <Badge variant={getPriorityVariant(order.priority)} className="text-xs">
-            {order.priority || "Normal"}
           </Badge>
           {order.incident_id && order.asset_id && (
             <Badge variant="outline" className="text-xs" asChild>
@@ -86,32 +116,102 @@ export function WorkOrderCardMobile({
           )}
         </div>
 
-        {/* Technician */}
+        {/* Technician with avatar */}
         <div className="flex items-center gap-2 text-sm">
-          <User className="h-4 w-4 text-muted-foreground shrink-0" />
-          <span className="truncate">{getTechnicianName(order.assigned_to)}</span>
+          <Avatar className="h-8 w-8 shrink-0 border border-border">
+            <AvatarFallback className="text-xs bg-muted text-muted-foreground">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <span className="truncate text-muted-foreground">{techName}</span>
         </div>
 
-        {/* Date */}
-        {order.planned_date && (
-          <div className="flex items-center gap-2 text-sm">
-            <Calendar className="h-4 w-4 text-muted-foreground shrink-0" />
-            <span className="truncate">{formatDate(order.planned_date)}</span>
-          </div>
-        )}
+        {/* Date + PO status in one row */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
+          {order.planned_date && (
+            <span className="flex items-center gap-1.5">
+              <Calendar className="h-4 w-4 shrink-0" />
+              {formatDateRelative(order.planned_date)}
+            </span>
+          )}
+          {order.purchase_order_id && (
+            <span className="flex items-center gap-1.5">
+              <ShoppingCart className="h-4 w-4 shrink-0" />
+              <Badge
+                variant={getPurchaseOrderStatusVariant(getPurchaseOrderStatus(order.purchase_order_id))}
+                className={cn(
+                  "text-xs",
+                  getPurchaseOrderStatusClass(getPurchaseOrderStatus(order.purchase_order_id))
+                )}
+              >
+                OC: {getPurchaseOrderStatus(order.purchase_order_id)}
+              </Badge>
+            </span>
+          )}
+        </div>
 
-        {/* Purchase Order Status */}
-        {order.purchase_order_id && (
-          <div className="flex items-center gap-2 text-sm">
-            <ShoppingCart className="h-4 w-4 text-muted-foreground shrink-0" />
-            <Badge
-              variant={getPurchaseOrderStatusVariant(getPurchaseOrderStatus(order.purchase_order_id))}
-              className={`text-xs ${getPurchaseOrderStatusClass(getPurchaseOrderStatus(order.purchase_order_id))}`}
-            >
-              OC: {getPurchaseOrderStatus(order.purchase_order_id)}
-            </Badge>
-          </div>
-        )}
+        {/* Actions: open bottom sheet */}
+        <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+          <SheetTrigger asChild>
+            <Button variant="outline" size="sm" className="w-full gap-2">
+              <MoreHorizontal className="h-4 w-4" />
+              Acciones
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="bottom" className="rounded-t-xl">
+            <SheetHeader>
+              <SheetTitle>OT {order.order_id}</SheetTitle>
+            </SheetHeader>
+            <div className="grid gap-1 py-4">
+              <Button variant="ghost" className="justify-start gap-3 h-12" asChild>
+                <Link href={`/ordenes/${order.id}`} onClick={() => setSheetOpen(false)}>
+                  <Eye className="h-4 w-4" />
+                  Ver detalles
+                </Link>
+              </Button>
+              {canEdit && (
+                <Button variant="ghost" className="justify-start gap-3 h-12" asChild>
+                  <Link href={`/ordenes/${order.id}/editar`} onClick={() => setSheetOpen(false)}>
+                    <Edit className="h-4 w-4" />
+                    Editar OT
+                  </Link>
+                </Button>
+              )}
+              {canEdit && order.status !== WorkOrderStatus.Completed && (
+                <Button variant="ghost" className="justify-start gap-3 h-12" asChild>
+                  <Link href={`/ordenes/${order.id}/completar`} onClick={() => setSheetOpen(false)}>
+                    <Wrench className="h-4 w-4" />
+                    Completar OT
+                  </Link>
+                </Button>
+              )}
+              {order.purchase_order_id && (
+                <Button variant="ghost" className="justify-start gap-3 h-12" asChild>
+                  <Link href={`/compras/${order.purchase_order_id}`} onClick={() => setSheetOpen(false)}>
+                    <ShoppingCart className="h-4 w-4" />
+                    Ver OC
+                  </Link>
+                </Button>
+              )}
+              {canDelete && (
+                <>
+                  <div className="my-2 border-t" />
+                  <Button
+                    variant="ghost"
+                    className="justify-start gap-3 h-12 text-red-600 hover:bg-red-50 hover:text-red-700"
+                    onClick={() => {
+                      setSheetOpen(false)
+                      onDeleteOrder(order)
+                    }}
+                  >
+                    <Trash className="h-4 w-4" />
+                    Eliminar OT
+                  </Button>
+                </>
+              )}
+            </div>
+          </SheetContent>
+        </Sheet>
       </CardContent>
     </Card>
   )

--- a/components/work-orders/work-order-card-mobile.tsx
+++ b/components/work-orders/work-order-card-mobile.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import Link from "next/link"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Calendar, Package, ShoppingCart, User } from "lucide-react"
+import { WorkOrderWithAsset } from "@/types"
+import { getStatusVariant, getTypeVariant, getPriorityVariant, getPurchaseOrderStatusVariant, getPurchaseOrderStatusClass, formatDate } from "./work-order-badges"
+import { WorkOrderActionsMenu } from "./work-order-actions-menu"
+
+export interface WorkOrderCardMobileProps {
+  order: WorkOrderWithAsset
+  getTechnicianName: (techId: string | null) => string
+  getPurchaseOrderStatus: (poId: string | null) => string
+  onDeleteOrder: (order: WorkOrderWithAsset) => void
+}
+
+export function WorkOrderCardMobile({
+  order,
+  getTechnicianName,
+  getPurchaseOrderStatus,
+  onDeleteOrder,
+}: WorkOrderCardMobileProps) {
+  return (
+    <Card className="w-full h-fit hover:shadow-md transition-shadow">
+      <CardHeader className="pb-3">
+        <div className="flex justify-between items-start">
+          <div className="space-y-1 flex-1 min-w-0">
+            <CardTitle className="text-lg font-semibold truncate">
+              {order.order_id}
+            </CardTitle>
+            <p className="text-sm text-muted-foreground line-clamp-2">
+              {order.description}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge variant={getStatusVariant(order.status)} className="shrink-0">
+              {order.status || "Pendiente"}
+            </Badge>
+            <WorkOrderActionsMenu
+              order={order}
+              getPurchaseOrderStatus={getPurchaseOrderStatus}
+              onDeleteOrder={onDeleteOrder}
+              variant="mobile"
+            />
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {/* Asset Info */}
+        <div className="flex items-center gap-2 text-sm">
+          <Package className="h-4 w-4 text-muted-foreground shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="font-medium truncate">
+              {order.asset?.name || "N/A"}
+            </p>
+            {order.asset?.asset_id && (
+              <p className="text-xs text-muted-foreground">
+                ID: {order.asset.asset_id}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Type and Priority */}
+        <div className="flex gap-2 flex-wrap items-center">
+          <Badge variant={getTypeVariant(order.type)} className="text-xs">
+            {order.type || "N/A"}
+          </Badge>
+          <Badge variant={getPriorityVariant(order.priority)} className="text-xs">
+            {order.priority || "Normal"}
+          </Badge>
+          {order.incident_id && order.asset_id && (
+            <Badge variant="outline" className="text-xs" asChild>
+              <Link href={`/activos/${order.asset_id}/incidentes`} className="hover:underline">
+                Desde incidente
+              </Link>
+            </Badge>
+          )}
+        </div>
+
+        {/* Technician */}
+        <div className="flex items-center gap-2 text-sm">
+          <User className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span className="truncate">{getTechnicianName(order.assigned_to)}</span>
+        </div>
+
+        {/* Date */}
+        {order.planned_date && (
+          <div className="flex items-center gap-2 text-sm">
+            <Calendar className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="truncate">{formatDate(order.planned_date)}</span>
+          </div>
+        )}
+
+        {/* Purchase Order Status */}
+        {order.purchase_order_id && (
+          <div className="flex items-center gap-2 text-sm">
+            <ShoppingCart className="h-4 w-4 text-muted-foreground shrink-0" />
+            <Badge
+              variant={getPurchaseOrderStatusVariant(getPurchaseOrderStatus(order.purchase_order_id))}
+              className={`text-xs ${getPurchaseOrderStatusClass(getPurchaseOrderStatus(order.purchase_order_id))}`}
+            >
+              OC: {getPurchaseOrderStatus(order.purchase_order_id)}
+            </Badge>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/work-orders/work-order-card-mobile.tsx
+++ b/components/work-orders/work-order-card-mobile.tsx
@@ -13,6 +13,8 @@ export interface WorkOrderCardMobileProps {
   getTechnicianName: (techId: string | null) => string
   getPurchaseOrderStatus: (poId: string | null) => string
   onDeleteOrder: (order: WorkOrderWithAsset) => void
+  canEdit?: boolean
+  canDelete?: boolean
 }
 
 export function WorkOrderCardMobile({
@@ -20,6 +22,8 @@ export function WorkOrderCardMobile({
   getTechnicianName,
   getPurchaseOrderStatus,
   onDeleteOrder,
+  canEdit = true,
+  canDelete = true,
 }: WorkOrderCardMobileProps) {
   return (
     <Card className="w-full h-fit hover:shadow-md transition-shadow">
@@ -42,6 +46,8 @@ export function WorkOrderCardMobile({
               getPurchaseOrderStatus={getPurchaseOrderStatus}
               onDeleteOrder={onDeleteOrder}
               variant="mobile"
+              canEdit={canEdit}
+              canDelete={canDelete}
             />
           </div>
         </div>

--- a/components/work-orders/work-order-create-button.tsx
+++ b/components/work-orders/work-order-create-button.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Plus } from "lucide-react"
+import { useAuthZustand } from "@/hooks/use-auth-zustand"
+
+/**
+ * Renders "Nueva OT" only when the current user has create access to work_orders.
+ * Used in the /ordenes page header.
+ */
+export function WorkOrderCreateButton() {
+  const { profile, hasCreateAccess } = useAuthZustand()
+  const role = profile?.business_role ?? profile?.role ?? null
+  const canCreate = role ? hasCreateAccess("work_orders") : false
+
+  if (!canCreate) {
+    return null
+  }
+
+  return (
+    <Button asChild>
+      <Link href="/ordenes/crear">
+        <Plus className="mr-2 h-4 w-4" />
+        Nueva OT
+      </Link>
+    </Button>
+  )
+}

--- a/components/work-orders/work-order-delete-dialog.tsx
+++ b/components/work-orders/work-order-delete-dialog.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { WorkOrderWithAsset } from "@/types"
+
+export interface WorkOrderDeleteDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  orderToDelete: WorkOrderWithAsset | null
+  onConfirm: () => Promise<void>
+  isDeleting: boolean
+}
+
+export function WorkOrderDeleteDialog({
+  open,
+  onOpenChange,
+  orderToDelete,
+  onConfirm,
+  isDeleting,
+}: WorkOrderDeleteDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            ¿Está seguro de eliminar esta orden de trabajo?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            Esta acción eliminará permanentemente la orden de trabajo{" "}
+            <strong>{orderToDelete?.order_id}</strong> y todos sus registros
+            relacionados.
+          </AlertDialogDescription>
+          <div className="space-y-3 pt-2">
+            <ul className="list-disc list-inside text-sm text-muted-foreground">
+              <li>Historial de mantenimiento</li>
+              <li>Problemas de checklist asociados</li>
+              <li>Órdenes de servicio relacionadas</li>
+              <li>Gastos adicionales</li>
+              <li>Órdenes de compra vinculadas</li>
+            </ul>
+            <div className="font-semibold text-destructive text-sm">
+              Esta acción no se puede deshacer.
+            </div>
+          </div>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isDeleting ? "Eliminando..." : "Eliminar"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/work-orders/work-orders-list.tsx
+++ b/components/work-orders/work-orders-list.tsx
@@ -9,6 +9,8 @@ import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { Search, AlertTriangle } from "lucide-react"
 import { createClient } from "@/lib/supabase"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useAuthZustand } from "@/hooks/use-auth-zustand"
+import { UI_PERMISSIONS } from "@/lib/auth/role-permissions"
 import Link from "next/link"
 import {
   WorkOrderWithAsset,
@@ -92,6 +94,16 @@ interface PlantOption {
 export function WorkOrdersList() {
   const isMobile = useIsMobile()
   const searchParams = useSearchParams()
+  const { profile, roleScope, organizationalContext } = useAuthZustand()
+  const userRole = profile?.business_role ?? profile?.role ?? null
+  const userId = profile?.id ?? null
+  const plantId = organizationalContext?.plantId ?? profile?.plant_id ?? null
+  const isPlantScoped = roleScope === "plant"
+  const isMecanico = userRole === "MECANICO"
+  const canEdit = userRole ? UI_PERMISSIONS.canShowEditButton(userRole, "work_orders") : false
+  const canDelete = userRole ? UI_PERMISSIONS.canShowDeleteButton(userRole, "work_orders") : false
+  const showPlantFilter = !isPlantScoped
+
   const [searchTerm, setSearchTerm] = useState("")
   const [workOrders, setWorkOrders] = useState<WorkOrderWithAsset[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -221,8 +233,15 @@ export function WorkOrdersList() {
     loadWorkOrders()
   }, [])
 
-  // Filter: plant_id, type, search, workflow (bar card)
+  // Filter: role scope (plant), MECANICO (assigned to me), plant_id, type, search, workflow (bar card)
   const filteredOrders = workOrders.filter((order) => {
+    if (isPlantScoped && plantId) {
+      const orderPlantId = getOrderPlantId(order)
+      if (orderPlantId !== plantId) return false
+    }
+    if (isMecanico && userId) {
+      if (order.assigned_to !== userId) return false
+    }
     if (plantFilter !== "all") {
       const orderPlantId = getOrderPlantId(order)
       if (orderPlantId !== plantFilter) return false
@@ -250,7 +269,17 @@ export function WorkOrdersList() {
     return true
   })
 
-  const workflowCounts = computeWorkflowCounts(workOrders)
+  const scopeFilteredOrders = workOrders.filter((order) => {
+    if (isPlantScoped && plantId) {
+      const orderPlantId = getOrderPlantId(order)
+      if (orderPlantId !== plantId) return false
+    }
+    if (isMecanico && userId) {
+      if (order.assigned_to !== userId) return false
+    }
+    return true
+  })
+  const workflowCounts = computeWorkflowCounts(scopeFilteredOrders)
 
   const getTechnicianName = (techId: string | null) => {
     if (!techId) return "No asignado"
@@ -307,19 +336,21 @@ export function WorkOrdersList() {
                     <SelectItem value="corrective">Correctivos</SelectItem>
                   </SelectContent>
                 </Select>
-                <Select value={plantFilter} onValueChange={setPlantFilter}>
-                  <SelectTrigger className={cn(isMobile ? "w-full h-11" : "w-full md:w-44")}>
-                    <SelectValue placeholder="Planta" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">Todas las plantas</SelectItem>
-                    {plants.map((p) => (
-                      <SelectItem key={p.id} value={p.id}>
-                        {p.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                {showPlantFilter && (
+                  <Select value={plantFilter} onValueChange={setPlantFilter}>
+                    <SelectTrigger className={cn(isMobile ? "w-full h-11" : "w-full md:w-44")}>
+                      <SelectValue placeholder="Planta" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Todas las plantas</SelectItem>
+                      {plants.map((p) => (
+                        <SelectItem key={p.id} value={p.id}>
+                          {p.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
               </div>
             </div>
 
@@ -336,6 +367,8 @@ export function WorkOrdersList() {
                 getTechnicianName={getTechnicianName}
                 getPurchaseOrderStatus={getPurchaseOrderStatus}
                 onDeleteOrder={handleDeleteWorkOrder}
+                canEdit={canEdit}
+                canDelete={canDelete}
               />
             ) : (
               <DesktopView
@@ -344,13 +377,15 @@ export function WorkOrdersList() {
                 getTechnicianName={getTechnicianName}
                 getPurchaseOrderStatus={getPurchaseOrderStatus}
                 onDeleteOrder={handleDeleteWorkOrder}
+                canEdit={canEdit}
+                canDelete={canDelete}
               />
             )}
           </CardContent>
 
           <CardFooter className={cn(isMobile && "px-4")}>
             <div className="text-xs text-muted-foreground">
-              Mostrando <strong>{filteredOrders.length}</strong> de <strong>{workOrders.length}</strong> órdenes de trabajo.
+              Mostrando <strong>{filteredOrders.length}</strong> de <strong>{scopeFilteredOrders.length}</strong> órdenes de trabajo.
             </div>
           </CardFooter>
         </Card>
@@ -368,18 +403,22 @@ export function WorkOrdersList() {
 }
 
 // Mobile View Component
-function MobileView({ 
-  orders, 
-  isLoading, 
-  getTechnicianName, 
+function MobileView({
+  orders,
+  isLoading,
+  getTechnicianName,
   getPurchaseOrderStatus,
-  onDeleteOrder
+  onDeleteOrder,
+  canEdit,
+  canDelete,
 }: {
   orders: WorkOrderWithAsset[]
   isLoading: boolean
   getTechnicianName: (techId: string | null) => string
   getPurchaseOrderStatus: (poId: string | null) => string
   onDeleteOrder: (order: WorkOrderWithAsset) => void
+  canEdit: boolean
+  canDelete: boolean
 }) {
   if (isLoading) {
     return (
@@ -409,6 +448,8 @@ function MobileView({
           getTechnicianName={getTechnicianName}
           getPurchaseOrderStatus={getPurchaseOrderStatus}
           onDeleteOrder={onDeleteOrder}
+          canEdit={canEdit}
+          canDelete={canDelete}
         />
       ))}
     </div>
@@ -422,12 +463,16 @@ function DesktopView({
   getTechnicianName,
   getPurchaseOrderStatus,
   onDeleteOrder,
+  canEdit,
+  canDelete,
 }: {
   orders: WorkOrderWithAsset[]
   isLoading: boolean
   getTechnicianName: (techId: string | null) => string
   getPurchaseOrderStatus: (poId: string | null) => string
   onDeleteOrder: (order: WorkOrderWithAsset) => void
+  canEdit: boolean
+  canDelete: boolean
 }) {
   if (isLoading) {
     return (
@@ -526,6 +571,8 @@ function DesktopView({
                   getPurchaseOrderStatus={getPurchaseOrderStatus}
                   onDeleteOrder={onDeleteOrder}
                   variant="desktop"
+                  canEdit={canEdit}
+                  canDelete={canDelete}
                 />
               </TableCell>
             </TableRow>

--- a/components/work-orders/work-orders-list.tsx
+++ b/components/work-orders/work-orders-list.tsx
@@ -1,321 +1,147 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { useSearchParams } from 'next/navigation'
-import { Button } from "@/components/ui/button"
+import { useSearchParams } from "next/navigation"
 import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { 
-  Check, CheckCircle, Edit, Eye, FileText, MoreHorizontal, Search, Trash, User, 
-  AlertTriangle, Wrench, CalendarDays, ListChecks, Plus, ShoppingCart, Filter,
-  ChevronRight, Calendar, Clock, Package
-} from "lucide-react"
+import { Card, CardContent, CardFooter } from "@/components/ui/card"
+import { Search, AlertTriangle } from "lucide-react"
 import { createClient } from "@/lib/supabase"
 import { useIsMobile } from "@/hooks/use-mobile"
 import Link from "next/link"
-import { WorkOrder, WorkOrderWithAsset, WorkOrderStatus, MaintenanceType, ServiceOrderPriority, Asset, Profile, PurchaseOrderStatus } from "@/types"
-import { 
-  Select, 
-  SelectContent, 
-  SelectItem, 
-  SelectTrigger, 
-  SelectValue 
+import {
+  WorkOrderWithAsset,
+  WorkOrderStatus,
+  MaintenanceType,
+  Profile,
+} from "@/types"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select"
 import { cn } from "@/lib/utils"
 import { PullToRefresh } from "@/components/ui/pull-to-refresh"
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
-import { useToast } from "@/hooks/use-toast"
+  getStatusVariant,
+  getTypeVariant,
+  getPriorityVariant,
+  getPurchaseOrderStatusVariant,
+  getPurchaseOrderStatusClass,
+  formatDate,
+} from "./work-order-badges"
+import { WorkOrderActionsMenu } from "./work-order-actions-menu"
+import { WorkOrderCardMobile } from "./work-order-card-mobile"
+import { useDeleteWorkOrder } from "./use-delete-work-order"
+import { WorkOrderDeleteDialog } from "./work-order-delete-dialog"
+import {
+  WorkflowSummaryBar,
+  type WorkflowSummaryFilter,
+  type WorkflowSummaryCounts,
+} from "./workflow-summary-bar"
 
-function getPriorityVariant(priority: string | null) {
-  switch (priority) {
-    case ServiceOrderPriority.Critical:
-      return "destructive"
-    case ServiceOrderPriority.High:
-      return "secondary" 
-    default:
-      return "outline"
-  }
+function getOrderPlantId(order: WorkOrderWithAsset): string | null {
+  return order.plant_id ?? order.asset?.plant_id ?? null
 }
 
-function getStatusVariant(status: string | null) {
-  switch (status) {
-    case WorkOrderStatus.Completed:
-      return "default" 
-    case WorkOrderStatus.InProgress:
-      return "secondary" 
-    case WorkOrderStatus.Pending:
-    case WorkOrderStatus.Quoted:
-    case WorkOrderStatus.Approved:
-      return "outline" 
-    default:
-      return "outline"
-  }
+function isOverdue(order: WorkOrderWithAsset): boolean {
+  if (order.status === WorkOrderStatus.Completed || !order.planned_date) return false
+  const planned = new Date(order.planned_date)
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  planned.setHours(0, 0, 0, 0)
+  return planned < today
 }
 
-function getTypeVariant(type: string | null) {
-  switch (type) {
-    case MaintenanceType.Preventive:
-      return "outline"
-    case MaintenanceType.Corrective:
-      return "destructive"
-    default:
-      return "secondary"
-  }
+function isActive(order: WorkOrderWithAsset): boolean {
+  return order.status === WorkOrderStatus.InProgress
 }
 
-function getPurchaseOrderStatusVariant(status: string) {
-  switch (status) {
-    case PurchaseOrderStatus.Pending:
-      return "outline"
-    case PurchaseOrderStatus.Approved:
-      return "secondary"
-    case PurchaseOrderStatus.Ordered:
-      return "default"
-    case PurchaseOrderStatus.Received:
-      return "default"
-    case PurchaseOrderStatus.Rejected:
-      return "destructive"
-    default:
-      return "outline"
-  }
+function isWaitingPo(order: WorkOrderWithAsset): boolean {
+  return Boolean(order.required_parts && !order.purchase_order_id)
 }
 
-function getPurchaseOrderStatusClass(status: string) {
-  switch (status) {
-    case PurchaseOrderStatus.Pending:
-      return "bg-yellow-50 text-yellow-800"
-    case PurchaseOrderStatus.Approved:
-      return "bg-blue-50 text-blue-800"
-    case PurchaseOrderStatus.Ordered:
-      return "bg-indigo-50 text-indigo-800"
-    case PurchaseOrderStatus.Received:
-      return "bg-green-100 text-green-800"
-    case PurchaseOrderStatus.Rejected:
-      return "bg-red-50 text-red-800"
-    default:
-      return ""
-  }
-}
-
-// Mobile-optimized WorkOrder Card Component
-function WorkOrderCard({ 
-  order, 
-  getTechnicianName, 
-  getPurchaseOrderStatus,
-  onDeleteOrder
-}: { 
-  order: WorkOrderWithAsset
-  getTechnicianName: (techId: string | null) => string
-  getPurchaseOrderStatus: (poId: string | null) => string
-  onDeleteOrder: (order: WorkOrderWithAsset) => void
-}) {
+function isTodayCompleted(order: WorkOrderWithAsset): boolean {
+  if (order.status !== WorkOrderStatus.Completed || !order.completed_at) return false
+  const completed = new Date(order.completed_at)
+  const today = new Date()
   return (
-    <Card className="w-full h-fit hover:shadow-md transition-shadow">
-      <CardHeader className="pb-3">
-        <div className="flex justify-between items-start">
-          <div className="space-y-1 flex-1 min-w-0">
-            <CardTitle className="text-lg font-semibold truncate">
-              {order.order_id}
-            </CardTitle>
-            <p className="text-sm text-muted-foreground line-clamp-2">
-              {order.description}
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Badge variant={getStatusVariant(order.status)} className="shrink-0">
-              {order.status || "Pendiente"}
-            </Badge>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="h-8 w-8 p-0">
-                  <span className="sr-only">Abrir menú</span>
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Acciones</DropdownMenuLabel>
-                <DropdownMenuItem asChild>
-                  <Link href={`/ordenes/${order.id}`}>
-                    <Eye className="mr-2 h-4 w-4" />
-                    <span>Ver Detalles</span>
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link href={`/ordenes/${order.id}/editar`}>
-                    <Edit className="mr-2 h-4 w-4" />
-                    <span>Editar OT</span>
-                  </Link>
-                </DropdownMenuItem>
-                {order.status !== WorkOrderStatus.Completed && (
-                  <DropdownMenuItem asChild>
-                    <Link href={`/ordenes/${order.id}/completar`}>
-                      <CheckCircle className="mr-2 h-4 w-4" />
-                      <span>Completar OT</span>
-                    </Link>
-                  </DropdownMenuItem>
-                )}
-                {order.purchase_order_id && (
-                  <DropdownMenuItem asChild>
-                    <Link href={`/compras/${order.purchase_order_id}`}>
-                      <ShoppingCart className="mr-2 h-4 w-4" />
-                      <span>Ver OC</span>
-                    </Link>
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem 
-                  className="text-red-600 hover:bg-red-50 hover:text-red-700"
-                  onClick={() => onDeleteOrder(order)}
-                >
-                  <Trash className="mr-2 h-4 w-4" />
-                  <span>Eliminar OT</span>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-      </CardHeader>
-      
-      <CardContent className="space-y-4">
-        {/* Asset Info */}
-        <div className="flex items-center gap-2 text-sm">
-          <Package className="h-4 w-4 text-muted-foreground shrink-0" />
-          <div className="flex-1 min-w-0">
-            <p className="font-medium truncate">
-              {order.asset?.name || 'N/A'}
-            </p>
-            {order.asset?.asset_id && (
-              <p className="text-xs text-muted-foreground">
-                ID: {order.asset.asset_id}
-              </p>
-            )}
-          </div>
-        </div>
-        
-        {/* Type and Priority */}
-        <div className="flex gap-2 flex-wrap items-center">
-          <Badge variant={getTypeVariant(order.type)} className="text-xs">
-            {order.type || 'N/A'}
-          </Badge>
-          <Badge variant={getPriorityVariant(order.priority)} className="text-xs">
-            {order.priority || 'Normal'}
-          </Badge>
-          {order.incident_id && order.asset_id && (
-            <Badge variant="outline" className="text-xs" asChild>
-              <Link href={`/activos/${order.asset_id}/incidentes`} className="hover:underline">
-                Desde incidente
-              </Link>
-            </Badge>
-          )}
-        </div>
-        
-        {/* Technician */}
-        <div className="flex items-center gap-2 text-sm">
-          <User className="h-4 w-4 text-muted-foreground shrink-0" />
-          <span className="truncate">{getTechnicianName(order.assigned_to)}</span>
-        </div>
-        
-        {/* Date */}
-        {order.planned_date && (
-          <div className="flex items-center gap-2 text-sm">
-            <Calendar className="h-4 w-4 text-muted-foreground shrink-0" />
-            <span className="truncate">{formatDate(order.planned_date)}</span>
-          </div>
-        )}
-        
-        {/* Purchase Order Status */}
-        {order.purchase_order_id && (
-          <div className="flex items-center gap-2 text-sm">
-            <ShoppingCart className="h-4 w-4 text-muted-foreground shrink-0" />
-            <Badge 
-              variant={getPurchaseOrderStatusVariant(getPurchaseOrderStatus(order.purchase_order_id))} 
-              className={`text-xs ${getPurchaseOrderStatusClass(getPurchaseOrderStatus(order.purchase_order_id))}`}
-            >
-              OC: {getPurchaseOrderStatus(order.purchase_order_id)}
-            </Badge>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+    completed.getFullYear() === today.getFullYear() &&
+    completed.getMonth() === today.getMonth() &&
+    completed.getDate() === today.getDate()
   )
 }
 
-// Utility function to properly cleanup modal state and focus
-const cleanupModalState = (callback: () => void, delay: number = 100) => {
-  setTimeout(() => {
-    callback()
-    // Force any modal overlays to be removed
-    const modalOverlays = document.querySelectorAll('[data-radix-focus-guard], [data-radix-scroll-lock-wrapper]')
-    modalOverlays.forEach(overlay => {
-      if (overlay.parentNode) {
-        overlay.parentNode.removeChild(overlay)
-      }
-    })
-    // Clear any stuck focus states
-    if (document.activeElement && document.activeElement !== document.body) {
-      (document.activeElement as HTMLElement).blur()
-    }
-    document.body.focus()
-    // Remove any aria-hidden attributes from the body that might be stuck
-    document.body.removeAttribute('aria-hidden')
-    document.body.style.removeProperty('pointer-events')
-  }, delay)
+function computeWorkflowCounts(orders: WorkOrderWithAsset[]): WorkflowSummaryCounts {
+  return {
+    overdue: orders.filter(isOverdue).length,
+    active: orders.filter(isActive).length,
+    waitingPo: orders.filter(isWaitingPo).length,
+    todayCompleted: orders.filter(isTodayCompleted).length,
+  }
+}
+
+interface PlantOption {
+  id: string
+  name: string
 }
 
 export function WorkOrdersList() {
   const isMobile = useIsMobile()
   const searchParams = useSearchParams()
   const [searchTerm, setSearchTerm] = useState("")
-  const [workOrders, setWorkOrders] = useState<WorkOrderWithAsset[]>([]) 
+  const [workOrders, setWorkOrders] = useState<WorkOrderWithAsset[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [activeTab, setActiveTab] = useState<string>("all")
   const [typeFilter, setTypeFilter] = useState<string>("all")
+  const [plantFilter, setPlantFilter] = useState<string>("all")
+  const [workflowFilter, setWorkflowFilter] = useState<WorkflowSummaryFilter>(null)
   const [technicians, setTechnicians] = useState<Record<string, Profile>>({})
   const [purchaseOrderStatuses, setPurchaseOrderStatuses] = useState<Record<string, string>>({})
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [orderToDelete, setOrderToDelete] = useState<WorkOrderWithAsset | null>(null)
-  const [isDeleting, setIsDeleting] = useState(false)
-  const { toast } = useToast()
+  const [plants, setPlants] = useState<PlantOption[]>([])
+
+  const {
+    openDelete: handleDeleteWorkOrder,
+    orderToDelete,
+    deleteDialogOpen,
+    setDeleteDialogOpen,
+    confirmDelete,
+    isDeleting,
+  } = useDeleteWorkOrder({
+    onDeleted: (order) => setWorkOrders((prev) => prev.filter((wo) => wo.id !== order.id)),
+  })
 
   // Initialize search term from URL parameters
   useEffect(() => {
-    const assetName = searchParams.get('asset')
-    const assetId = searchParams.get('assetId')
-    if (assetName) {
-      setSearchTerm(assetName)
-    } else if (assetId) {
-      // If we have assetId but no asset name, we'll use it to filter
-      setSearchTerm(assetId)
-    }
+    const assetName = searchParams.get("asset")
+    const assetId = searchParams.get("assetId")
+    if (assetName) setSearchTerm(assetName)
+    else if (assetId) setSearchTerm(assetId)
   }, [searchParams])
 
-  // Load work orders function
+  // Fetch plants on mount
+  useEffect(() => {
+    async function fetchPlants() {
+      try {
+        const res = await fetch("/api/plants")
+        if (!res.ok) return
+        const json = await res.json()
+        const list = Array.isArray(json.plants) ? json.plants : []
+        setPlants(list.map((p: { id: string; name: string }) => ({ id: p.id, name: p.name || p.id })))
+      } catch (e) {
+        console.error("Error fetching plants:", e)
+      }
+    }
+    fetchPlants()
+  }, [])
+
   const loadWorkOrders = async () => {
     try {
       setIsLoading(true)
       const supabase = createClient()
 
-      // Load work orders first
       const { data, error } = await supabase
         .from("work_orders")
         .select(`
@@ -323,7 +149,8 @@ export function WorkOrdersList() {
           asset:assets (
             id,
             name,
-            asset_id
+            asset_id,
+            plant_id
           )
         `)
         .order("created_at", { ascending: false })
@@ -333,15 +160,12 @@ export function WorkOrdersList() {
         throw error
       }
 
-      setWorkOrders(data as WorkOrderWithAsset[])
+      setWorkOrders((data as WorkOrderWithAsset[]) ?? [])
 
-      // Get unique technician IDs from work orders
-      const assignedIds = data
-        .filter(order => order.assigned_to)
-        .map(order => order.assigned_to as string)
+      const assignedIds = (data ?? [])
+        .filter((o) => o.assigned_to)
+        .map((o) => o.assigned_to as string)
       const uniqueAssignedIds = [...new Set(assignedIds)]
-
-      // Load technicians: active ones + assigned to work orders (even if inactive) so names always show
       const techMap: Record<string, Profile> = {}
 
       const { data: activeTechs, error: activeTechError } = await supabase
@@ -351,7 +175,7 @@ export function WorkOrdersList() {
         .limit(500)
 
       if (!activeTechError && activeTechs) {
-        activeTechs.forEach(tech => {
+        activeTechs.forEach((tech) => {
           techMap[tech.id] = tech
         })
       }
@@ -361,41 +185,33 @@ export function WorkOrdersList() {
           .from("profiles")
           .select("id, nombre, apellido")
           .in("id", uniqueAssignedIds)
-
         if (!assignedTechError && assignedTechs) {
-          assignedTechs.forEach(tech => {
+          assignedTechs.forEach((tech) => {
             techMap[tech.id] = tech
           })
         }
       }
-
       setTechnicians(techMap)
 
-      // Load purchase order statuses
-      const poIds = data
-        .filter(order => order.purchase_order_id)
-        .map(order => order.purchase_order_id as string)
-      
+      const poIds = (data ?? [])
+        .filter((o) => o.purchase_order_id)
+        .map((o) => o.purchase_order_id as string)
       if (poIds.length > 0) {
         const { data: poData, error: poError } = await supabase
           .from("purchase_orders")
           .select("id, status")
           .in("id", poIds)
-          
-        if (poError) {
-          console.error("Error al cargar estados de órdenes de compra:", poError)
-        } else if (poData) {
+        if (!poError && poData) {
           const statusMap: Record<string, string> = {}
-          poData.forEach(po => {
+          poData.forEach((po) => {
             statusMap[po.id] = po.status
           })
           setPurchaseOrderStatuses(statusMap)
         }
       }
-
     } catch (error) {
       console.error("Error al cargar órdenes de trabajo:", error)
-      setWorkOrders([]) 
+      setWorkOrders([])
     } finally {
       setIsLoading(false)
     }
@@ -405,114 +221,52 @@ export function WorkOrdersList() {
     loadWorkOrders()
   }, [])
 
-  // Filter logic
-  const filteredOrdersByTab = workOrders.filter(order => {
-    if (activeTab === "all") return true
-    if (activeTab === "pending") return order.status === WorkOrderStatus.Pending || order.status === WorkOrderStatus.Quoted
-    if (activeTab === "approved") return order.status === WorkOrderStatus.Approved
-    if (activeTab === "inprogress") return order.status === WorkOrderStatus.InProgress
-    if (activeTab === "completed") return order.status === WorkOrderStatus.Completed
-    return true
-  }).filter(order => {
-    if (typeFilter === "all") return true
-    if (typeFilter === "preventive") return order.type === MaintenanceType.Preventive
-    if (typeFilter === "corrective") return order.type === MaintenanceType.Corrective
+  // Filter: plant_id, type, search, workflow (bar card)
+  const filteredOrders = workOrders.filter((order) => {
+    if (plantFilter !== "all") {
+      const orderPlantId = getOrderPlantId(order)
+      if (orderPlantId !== plantFilter) return false
+    }
+    if (typeFilter !== "all") {
+      if (typeFilter === "preventive" && order.type !== MaintenanceType.Preventive) return false
+      if (typeFilter === "corrective" && order.type !== MaintenanceType.Corrective) return false
+    }
+    const assetIdParam = searchParams.get("assetId")
+    if (assetIdParam && order.asset_id !== assetIdParam) return false
+    const term = searchTerm.toLowerCase()
+    if (term) {
+      const match =
+        (order.asset?.name?.toLowerCase() ?? "").includes(term) ||
+        (order.asset?.asset_id?.toLowerCase() ?? "").includes(term) ||
+        (order.order_id?.toLowerCase() ?? "").includes(term) ||
+        (order.assigned_to && technicians[order.assigned_to]?.nombre?.toLowerCase().includes(term)) ||
+        (order.description?.toLowerCase() ?? "").includes(term)
+      if (!match) return false
+    }
+    if (workflowFilter === "overdue") return isOverdue(order)
+    if (workflowFilter === "active") return isActive(order)
+    if (workflowFilter === "waiting_po") return isWaitingPo(order)
+    if (workflowFilter === "today_completed") return isTodayCompleted(order)
     return true
   })
 
-  const filteredOrders = filteredOrdersByTab.filter(
-    (order) => {
-      // If we have a specific assetId in URL params, filter by that first
-      const assetIdParam = searchParams.get('assetId')
-      if (assetIdParam && order.asset_id !== assetIdParam) {
-        return false
-      }
-      
-      // Then apply search term filter
-      return (
-        (order.asset?.name?.toLowerCase() || "").includes(searchTerm.toLowerCase()) ||
-        (order.asset?.asset_id?.toLowerCase() || "").includes(searchTerm.toLowerCase()) ||
-        (order.order_id?.toLowerCase() || "").includes(searchTerm.toLowerCase()) || 
-        (order.assigned_to && technicians[order.assigned_to]?.nombre?.toLowerCase().includes(searchTerm.toLowerCase())) ||
-        (order.description?.toLowerCase() || "").includes(searchTerm.toLowerCase())
-      )
-    }
-  )
+  const workflowCounts = computeWorkflowCounts(workOrders)
 
-  // Helper functions
   const getTechnicianName = (techId: string | null) => {
-    if (!techId) return 'No asignado'
+    if (!techId) return "No asignado"
     const tech = technicians[techId]
     if (!tech) return techId
-    return tech.nombre && tech.apellido 
-      ? `${tech.nombre} ${tech.apellido}`
-      : tech.nombre || techId
+    return tech.nombre && tech.apellido ? `${tech.nombre} ${tech.apellido}` : tech.nombre || techId
   }
 
   const getPurchaseOrderStatus = (poId: string | null): string => {
-    if (!poId) return 'N/A'
-    return purchaseOrderStatuses[poId] || 'N/A'
+    if (!poId) return "N/A"
+    return purchaseOrderStatuses[poId] ?? "N/A"
   }
 
-  // Pull to refresh handler
   const handlePullToRefresh = async () => {
     await loadWorkOrders()
-    await new Promise(resolve => setTimeout(resolve, 500))
-  }
-
-  // Delete work order function
-  const handleDeleteWorkOrder = async (order: WorkOrderWithAsset) => {
-    setOrderToDelete(order)
-    setDeleteDialogOpen(true)
-  }
-
-  const confirmDelete = async () => {
-    if (!orderToDelete) return
-
-    setIsDeleting(true)
-    try {
-      const supabase = createClient()
-      
-      const { error } = await supabase
-        .from("work_orders")
-        .delete()
-        .eq("id", orderToDelete.id)
-
-      if (error) {
-        console.error("Error al eliminar orden de trabajo:", error)
-        toast({
-          title: "Error",
-          description: "No se pudo eliminar la orden de trabajo. Por favor, intente nuevamente.",
-          variant: "destructive",
-        })
-        setIsDeleting(false)
-      } else {
-        toast({
-          title: "Orden eliminada",
-          description: `La orden de trabajo ${orderToDelete.order_id} ha sido eliminada exitosamente.`,
-        })
-        
-        // Remove the deleted order from the list
-        setWorkOrders(prev => prev.filter(wo => wo.id !== orderToDelete.id))
-        
-        // Close dialog with proper cleanup
-        setIsDeleting(false)
-        setDeleteDialogOpen(false)
-        
-        // Reset order state after a brief delay to ensure dialog closes properly
-        cleanupModalState(() => {
-          setOrderToDelete(null)
-        }, 100)
-      }
-    } catch (error) {
-      console.error("Error al eliminar orden de trabajo:", error)
-      toast({
-        title: "Error",
-        description: "Ocurrió un error inesperado. Por favor, intente nuevamente.",
-        variant: "destructive",
-      })
-      setIsDeleting(false)
-    }
+    await new Promise((resolve) => setTimeout(resolve, 500))
   }
 
   return (
@@ -521,34 +275,30 @@ export function WorkOrdersList() {
         <Card>
           <CardContent className={cn("pt-6", isMobile && "px-4 pt-4")}>
             {/* Search and Filters */}
-            <div className={cn(
-              "flex gap-4 mb-6",
-              isMobile ? "flex-col gap-3" : "flex-col md:flex-row md:items-center md:justify-between"
-            )}>
-              <div className={cn(
-                "flex items-center gap-2",
-                isMobile ? "flex-col gap-3" : "flex-col md:flex-row"
-              )}>
-                <div className={cn(
-                  "relative",
-                  isMobile ? "w-full" : "w-full md:w-64"
-                )}>
+            <div
+              className={cn(
+                "flex gap-4 mb-4",
+                isMobile ? "flex-col gap-3" : "flex-col md:flex-row md:items-center md:justify-between"
+              )}
+            >
+              <div
+                className={cn(
+                  "flex items-center gap-2",
+                  isMobile ? "flex-col gap-3" : "flex-col md:flex-row"
+                )}
+              >
+                <div className={cn("relative", isMobile ? "w-full" : "w-full md:w-64")}>
                   <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
                   <Input
                     type="search"
                     placeholder="Buscar OT, activo, asignado..."
-                    className={cn(
-                      "pl-8",
-                      isMobile && "h-11" // Better touch target
-                    )}
+                    className={cn("pl-8", isMobile && "h-11")}
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
                   />
                 </div>
                 <Select value={typeFilter} onValueChange={setTypeFilter}>
-                  <SelectTrigger className={cn(
-                    isMobile ? "w-full h-11" : "w-full md:w-40"
-                  )}>
+                  <SelectTrigger className={cn(isMobile ? "w-full h-11" : "w-full md:w-40")}>
                     <SelectValue placeholder="Filtrar por tipo" />
                   </SelectTrigger>
                   <SelectContent>
@@ -557,171 +307,47 @@ export function WorkOrdersList() {
                     <SelectItem value="corrective">Correctivos</SelectItem>
                   </SelectContent>
                 </Select>
+                <Select value={plantFilter} onValueChange={setPlantFilter}>
+                  <SelectTrigger className={cn(isMobile ? "w-full h-11" : "w-full md:w-44")}>
+                    <SelectValue placeholder="Planta" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Todas las plantas</SelectItem>
+                    {plants.map((p) => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {p.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
-            
-            {/* Tabs */}
-            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-              <TabsList className={cn(
-                "mb-4 grid w-full",
-                isMobile 
-                  ? "grid-cols-2 h-auto gap-1" // Stack in 2 columns on mobile
-                  : "grid-cols-2 sm:grid-cols-5"
-              )}>
-                <TabsTrigger 
-                  value="all"
-                  className={cn(isMobile && "text-xs px-2 py-2")}
-                >
-                  Todas
-                </TabsTrigger>
-                <TabsTrigger 
-                  value="pending"
-                  className={cn(isMobile && "text-xs px-2 py-2")}
-                >
-                  Pendientes
-                </TabsTrigger>
-                {!isMobile && (
-                  <>
-                    <TabsTrigger value="approved">Aprobadas</TabsTrigger>
-                    <TabsTrigger value="inprogress">En Progreso</TabsTrigger>
-                    <TabsTrigger value="completed">Completadas</TabsTrigger>
-                  </>
-                )}
-              </TabsList>
-              
-              {/* Mobile: Additional tabs in second grid */}
-              {isMobile && (
-                <div className="grid grid-cols-3 gap-1 mb-4">
-                  <Button
-                    variant={activeTab === "approved" ? "default" : "outline"}
-                    size="sm"
-                    onClick={() => setActiveTab("approved")}
-                    className="text-xs h-8"
-                  >
-                    Aprobadas
-                  </Button>
-                  <Button
-                    variant={activeTab === "inprogress" ? "default" : "outline"}
-                    size="sm"
-                    onClick={() => setActiveTab("inprogress")}
-                    className="text-xs h-8"
-                  >
-                    En Progreso
-                  </Button>
-                  <Button
-                    variant={activeTab === "completed" ? "default" : "outline"}
-                    size="sm"
-                    onClick={() => setActiveTab("completed")}
-                    className="text-xs h-8"
-                  >
-                    Completadas
-                  </Button>
-                </div>
-              )}
-              
-              {/* Content for each tab */}
-              <TabsContent value="all" className="mt-0">
-                {isMobile ? (
-                  <MobileView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                ) : (
-                  <DesktopView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                )}
-              </TabsContent>
-              
-              <TabsContent value="pending" className="mt-0">
-                {isMobile ? (
-                  <MobileView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                ) : (
-                  <DesktopView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                )}
-              </TabsContent>
-              
-              <TabsContent value="approved" className="mt-0">
-                {isMobile ? (
-                  <MobileView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                ) : (
-                  <DesktopView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                )}
-              </TabsContent>
-              
-              <TabsContent value="inprogress" className="mt-0">
-                {isMobile ? (
-                  <MobileView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                ) : (
-                  <DesktopView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                )}
-              </TabsContent>
-              
-              <TabsContent value="completed" className="mt-0">
-                {isMobile ? (
-                  <MobileView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                ) : (
-                  <DesktopView 
-                    orders={filteredOrders} 
-                    isLoading={isLoading} 
-                    getTechnicianName={getTechnicianName}
-                    getPurchaseOrderStatus={getPurchaseOrderStatus}
-                    onDeleteOrder={handleDeleteWorkOrder}
-                  />
-                )}
-              </TabsContent>
-            </Tabs>
+
+            <WorkflowSummaryBar
+              counts={workflowCounts}
+              activeFilter={workflowFilter}
+              onFilterChange={setWorkflowFilter}
+            />
+
+            {isMobile ? (
+              <MobileView
+                orders={filteredOrders}
+                isLoading={isLoading}
+                getTechnicianName={getTechnicianName}
+                getPurchaseOrderStatus={getPurchaseOrderStatus}
+                onDeleteOrder={handleDeleteWorkOrder}
+              />
+            ) : (
+              <DesktopView
+                orders={filteredOrders}
+                isLoading={isLoading}
+                getTechnicianName={getTechnicianName}
+                getPurchaseOrderStatus={getPurchaseOrderStatus}
+                onDeleteOrder={handleDeleteWorkOrder}
+              />
+            )}
           </CardContent>
-          
+
           <CardFooter className={cn(isMobile && "px-4")}>
             <div className="text-xs text-muted-foreground">
               Mostrando <strong>{filteredOrders.length}</strong> de <strong>{workOrders.length}</strong> órdenes de trabajo.
@@ -730,37 +356,13 @@ export function WorkOrdersList() {
         </Card>
       </PullToRefresh>
 
-      {/* Delete confirmation dialog */}
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>¿Está seguro de eliminar esta orden de trabajo?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Esta acción eliminará permanentemente la orden de trabajo <strong>{orderToDelete?.order_id}</strong> y todos sus registros relacionados.
-            </AlertDialogDescription>
-            <div className="space-y-3 pt-2">
-              <ul className="list-disc list-inside text-sm text-muted-foreground">
-                <li>Historial de mantenimiento</li>
-                <li>Problemas de checklist asociados</li>
-                <li>Órdenes de servicio relacionadas</li>
-                <li>Gastos adicionales</li>
-                <li>Órdenes de compra vinculadas</li>
-              </ul>
-              <div className="font-semibold text-destructive text-sm">Esta acción no se puede deshacer.</div>
-            </div>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={confirmDelete}
-              disabled={isDeleting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {isDeleting ? "Eliminando..." : "Eliminar"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <WorkOrderDeleteDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        orderToDelete={orderToDelete}
+        onConfirm={confirmDelete}
+        isDeleting={isDeleting}
+      />
     </>
   )
 }
@@ -801,7 +403,7 @@ function MobileView({
   return (
     <div className="space-y-4">
       {orders.map((order) => (
-        <WorkOrderCard 
+        <WorkOrderCardMobile
           key={order.id}
           order={order}
           getTechnicianName={getTechnicianName}
@@ -814,12 +416,12 @@ function MobileView({
 }
 
 // Desktop View Component (existing table)
-function DesktopView({ 
-  orders, 
-  isLoading, 
-  getTechnicianName, 
+function DesktopView({
+  orders,
+  isLoading,
+  getTechnicianName,
   getPurchaseOrderStatus,
-  onDeleteOrder
+  onDeleteOrder,
 }: {
   orders: WorkOrderWithAsset[]
   isLoading: boolean
@@ -878,126 +480,53 @@ function DesktopView({
                 </div>
               </TableCell>
               <TableCell>
-                {order.asset?.name || 'N/A'} 
-                {order.asset?.asset_id && <span className="text-xs text-muted-foreground ml-1">({order.asset.asset_id})</span>}
+                {order.asset?.name || "N/A"}
+                {order.asset?.asset_id && (
+                  <span className="text-xs text-muted-foreground ml-1">({order.asset.asset_id})</span>
+                )}
               </TableCell>
               <TableCell>
                 <Badge variant={getTypeVariant(order.type)} className="capitalize">
-                  {order.type || 'N/A'}
+                  {order.type || "N/A"}
                 </Badge>
               </TableCell>
               <TableCell>
                 <Badge variant={getPriorityVariant(order.priority)} className="capitalize">
-                  {order.priority || 'N/A'}
+                  {order.priority || "N/A"}
                 </Badge>
               </TableCell>
               <TableCell>
                 <Badge variant={getStatusVariant(order.status)} className="capitalize">
-                  {order.status || 'N/A'}
+                  {order.status || "N/A"}
                 </Badge>
               </TableCell>
               <TableCell>
                 {order.purchase_order_id ? (
-                  <Badge 
-                    variant={getPurchaseOrderStatusVariant(getPurchaseOrderStatus(order.purchase_order_id))} 
+                  <Badge
+                    variant={getPurchaseOrderStatusVariant(getPurchaseOrderStatus(order.purchase_order_id))}
                     className={getPurchaseOrderStatusClass(getPurchaseOrderStatus(order.purchase_order_id))}
                   >
                     {getPurchaseOrderStatus(order.purchase_order_id)}
                   </Badge>
+                ) : order.type === MaintenanceType.Preventive && order.required_parts ? (
+                  <Badge variant="outline" className="bg-yellow-50 text-yellow-800">
+                    Pendiente
+                  </Badge>
                 ) : (
-                  order.type === MaintenanceType.Preventive && order.required_parts ? (
-                    <Badge variant="outline" className="bg-yellow-50 text-yellow-800">Pendiente</Badge>
-                  ) : (
-                    <span className="text-xs text-muted-foreground">N/A</span>
-                  )
+                  <span className="text-xs text-muted-foreground">N/A</span>
                 )}
               </TableCell>
-              <TableCell>{order.planned_date ? formatDate(order.planned_date) : 'No planificada'}</TableCell>
-              <TableCell>{getTechnicianName(order.assigned_to)}</TableCell> 
+              <TableCell>
+                {order.planned_date ? formatDate(order.planned_date) : "No planificada"}
+              </TableCell>
+              <TableCell>{getTechnicianName(order.assigned_to)}</TableCell>
               <TableCell className="text-right">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="h-8 w-8 p-0">
-                      <span className="sr-only">Abrir menú</span>
-                      <MoreHorizontal className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuLabel>Acciones</DropdownMenuLabel>
-                    <DropdownMenuItem asChild>
-                      <Link href={`/ordenes/${order.id}`}>
-                        <Eye className="mr-2 h-4 w-4" />
-                        <span>Ver Detalles</span>
-                      </Link>
-                    </DropdownMenuItem>
-                  {/* Link to Service Order if exists (client-side discovery) */}
-                  <DropdownMenuItem asChild>
-                    <Link href={`/servicios?workOrderId=${order.id}`}>
-                      <FileText className="mr-2 h-4 w-4" />
-                      <span>Ver Servicio</span>
-                    </Link>
-                  </DropdownMenuItem>
-                  {/* Link to Incident if present on order */}
-                  {order.incident_id && order.asset_id && (
-                    <DropdownMenuItem asChild>
-                      <Link href={`/activos/${order.asset_id}/incidentes`}>
-                        <AlertTriangle className="mr-2 h-4 w-4" />
-                        <span>Incidente</span>
-                      </Link>
-                    </DropdownMenuItem>
-                  )}
-                    <DropdownMenuItem asChild>
-                       <Link href={`/ordenes/${order.id}/editar`}> 
-                        <Edit className="mr-2 h-4 w-4" />
-                        <span>Editar OT</span>
-                      </Link>
-                    </DropdownMenuItem>
-                    {!order.purchase_order_id && order.required_parts && (
-                      <DropdownMenuItem asChild>
-                        <Link href={`/ordenes/${order.id}/generar-oc`}>
-                          <ShoppingCart className="mr-2 h-4 w-4" />
-                          <span>Generar OC</span>
-                        </Link>
-                      </DropdownMenuItem>
-                    )}
-                    {order.purchase_order_id && (
-                      <DropdownMenuItem asChild>
-                        <Link href={`/compras/${order.purchase_order_id}`}>
-                          <ShoppingCart className="mr-2 h-4 w-4" />
-                          <span>Ver OC</span>
-                        </Link>
-                      </DropdownMenuItem>
-                    )}
-                    <DropdownMenuItem>
-                      <ListChecks className="mr-2 h-4 w-4" />
-                      <span>Ver Checklist</span> 
-                    </DropdownMenuItem>
-                    {order.status !== WorkOrderStatus.Completed && (
-                      <DropdownMenuItem asChild>
-                        <Link href={`/ordenes/${order.id}/completar`}>
-                          <Wrench className="mr-2 h-4 w-4" />
-                          <span>Registrar Mantenimiento</span>
-                        </Link>
-                      </DropdownMenuItem>
-                    )}
-                    <DropdownMenuItem>
-                      <CalendarDays className="mr-2 h-4 w-4" />
-                      <span>Re-Programar</span>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem>
-                      <CheckCircle className="mr-2 h-4 w-4" />
-                      <span>Cambiar Estado</span>
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem 
-                      className="text-red-600 hover:bg-red-50 hover:text-red-700"
-                      onClick={() => onDeleteOrder(order)}
-                    >
-                      <Trash className="mr-2 h-4 w-4" />
-                      <span>Eliminar OT</span>
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <WorkOrderActionsMenu
+                  order={order}
+                  getPurchaseOrderStatus={getPurchaseOrderStatus}
+                  onDeleteOrder={onDeleteOrder}
+                  variant="desktop"
+                />
               </TableCell>
             </TableRow>
           ))}
@@ -1005,22 +534,4 @@ function DesktopView({
       </Table>
     </div>
   )
-}
-
-function formatDate(dateString: string | null) {
-  if (!dateString) return "N/A"
-  try {
-    const date = new Date(dateString)
-    if (isNaN(date.getTime())) {
-      return dateString
-    }
-    return new Intl.DateTimeFormat("es-ES", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    }).format(date)
-  } catch (error) {
-    console.warn("Error formatting date:", dateString, error)
-    return dateString
-  }
 } 

--- a/components/work-orders/work-orders-list.tsx
+++ b/components/work-orders/work-orders-list.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Search, AlertTriangle } from "lucide-react"
+import { Search, AlertTriangle, Filter, X } from "lucide-react"
 import { createClient } from "@/lib/supabase"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useAuthZustand } from "@/hooks/use-auth-zustand"
@@ -29,15 +29,25 @@ import { cn } from "@/lib/utils"
 import { PullToRefresh } from "@/components/ui/pull-to-refresh"
 import {
   getStatusVariant,
+  getStatusDotClass,
+  getPriorityDotClass,
   getTypeVariant,
   getPriorityVariant,
   getPurchaseOrderStatusVariant,
   getPurchaseOrderStatusClass,
   formatDate,
+  formatDateRelative,
 } from "./work-order-badges"
 import { WorkOrderActionsMenu } from "./work-order-actions-menu"
 import { WorkOrderCardMobile } from "./work-order-card-mobile"
 import { useDeleteWorkOrder } from "./use-delete-work-order"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { Button } from "@/components/ui/button"
 import { WorkOrderDeleteDialog } from "./work-order-delete-dialog"
 import {
   WorkflowSummaryBar,
@@ -303,56 +313,137 @@ export function WorkOrdersList() {
       <PullToRefresh onRefresh={handlePullToRefresh} disabled={isLoading}>
         <Card>
           <CardContent className={cn("pt-6", isMobile && "px-4 pt-4")}>
-            {/* Search and Filters */}
-            <div
-              className={cn(
-                "flex gap-4 mb-4",
-                isMobile ? "flex-col gap-3" : "flex-col md:flex-row md:items-center md:justify-between"
-              )}
-            >
-              <div
-                className={cn(
-                  "flex items-center gap-2",
-                  isMobile ? "flex-col gap-3" : "flex-col md:flex-row"
-                )}
-              >
-                <div className={cn("relative", isMobile ? "w-full" : "w-full md:w-64")}>
-                  <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    type="search"
-                    placeholder="Buscar OT, activo, asignado..."
-                    className={cn("pl-8", isMobile && "h-11")}
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                  />
+            {/* Filter bar: inline on desktop, collapsible on mobile */}
+            {(() => {
+              const activeFilterCount = [
+                searchTerm.trim(),
+                typeFilter !== "all",
+                plantFilter !== "all",
+                workflowFilter !== null,
+              ].filter(Boolean).length
+              const hasFilters = activeFilterCount > 0
+              const clearFilters = () => {
+                setSearchTerm("")
+                setTypeFilter("all")
+                setPlantFilter("all")
+                setWorkflowFilter(null)
+              }
+              return (
+                <div className="mb-4 md:mb-5">
+                  {isMobile ? (
+                    <Collapsible defaultOpen={false}>
+                      <div className="flex items-center gap-2">
+                        <CollapsibleTrigger asChild>
+                          <Button variant="outline" size="sm" className="gap-2">
+                            <Filter className="h-4 w-4" />
+                            Filtros
+                            {activeFilterCount > 0 && (
+                              <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-xs font-medium text-primary-foreground">
+                                {activeFilterCount}
+                              </span>
+                            )}
+                          </Button>
+                        </CollapsibleTrigger>
+                        {hasFilters && (
+                          <Button variant="ghost" size="sm" onClick={clearFilters} className="text-muted-foreground">
+                            <X className="h-4 w-4 mr-1" />
+                            Limpiar
+                          </Button>
+                        )}
+                      </div>
+                      <CollapsibleContent>
+                        <div className="mt-3 flex flex-col gap-3">
+                          <div className="relative">
+                            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                            <Input
+                              type="search"
+                              placeholder="Buscar OT, activo, asignado..."
+                              className="pl-8 h-11"
+                              value={searchTerm}
+                              onChange={(e) => setSearchTerm(e.target.value)}
+                            />
+                          </div>
+                          <Select value={typeFilter} onValueChange={setTypeFilter}>
+                            <SelectTrigger className="w-full h-11">
+                              <SelectValue placeholder="Tipo" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="all">Todos los tipos</SelectItem>
+                              <SelectItem value="preventive">Preventivos</SelectItem>
+                              <SelectItem value="corrective">Correctivos</SelectItem>
+                            </SelectContent>
+                          </Select>
+                          {showPlantFilter && (
+                            <Select value={plantFilter} onValueChange={setPlantFilter}>
+                              <SelectTrigger className="w-full h-11">
+                                <SelectValue placeholder="Planta" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="all">Todas las plantas</SelectItem>
+                                {plants.map((p) => (
+                                  <SelectItem key={p.id} value={p.id}>
+                                    {p.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          )}
+                        </div>
+                      </CollapsibleContent>
+                    </Collapsible>
+                  ) : (
+                    <div className="flex flex-wrap items-center gap-3">
+                      <div className="relative w-64">
+                        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                        <Input
+                          type="search"
+                          placeholder="Buscar OT, activo, asignado..."
+                          className="pl-8"
+                          value={searchTerm}
+                          onChange={(e) => setSearchTerm(e.target.value)}
+                        />
+                      </div>
+                      <Select value={typeFilter} onValueChange={setTypeFilter}>
+                        <SelectTrigger className="w-[160px]">
+                          <SelectValue placeholder="Tipo" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">Todos los tipos</SelectItem>
+                          <SelectItem value="preventive">Preventivos</SelectItem>
+                          <SelectItem value="corrective">Correctivos</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      {showPlantFilter && (
+                        <Select value={plantFilter} onValueChange={setPlantFilter}>
+                          <SelectTrigger className="w-[180px]">
+                            <SelectValue placeholder="Planta" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">Todas las plantas</SelectItem>
+                            {plants.map((p) => (
+                              <SelectItem key={p.id} value={p.id}>
+                                {p.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
+                      {hasFilters && (
+                        <Button variant="ghost" size="sm" onClick={clearFilters} className="text-muted-foreground gap-1">
+                          <X className="h-4 w-4" />
+                          Limpiar filtros
+                        </Button>
+                      )}
+                      {activeFilterCount > 0 && (
+                        <span className="text-xs text-muted-foreground">
+                          {activeFilterCount} filtro{activeFilterCount !== 1 ? "s" : ""} activo{activeFilterCount !== 1 ? "s" : ""}
+                        </span>
+                      )}
+                    </div>
+                  )}
                 </div>
-                <Select value={typeFilter} onValueChange={setTypeFilter}>
-                  <SelectTrigger className={cn(isMobile ? "w-full h-11" : "w-full md:w-40")}>
-                    <SelectValue placeholder="Filtrar por tipo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">Todos los tipos</SelectItem>
-                    <SelectItem value="preventive">Preventivos</SelectItem>
-                    <SelectItem value="corrective">Correctivos</SelectItem>
-                  </SelectContent>
-                </Select>
-                {showPlantFilter && (
-                  <Select value={plantFilter} onValueChange={setPlantFilter}>
-                    <SelectTrigger className={cn(isMobile ? "w-full h-11" : "w-full md:w-44")}>
-                      <SelectValue placeholder="Planta" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">Todas las plantas</SelectItem>
-                      {plants.map((p) => (
-                        <SelectItem key={p.id} value={p.id}>
-                          {p.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              </div>
-            </div>
+              )
+            })()}
 
             <WorkflowSummaryBar
               counts={workflowCounts}
@@ -374,6 +465,7 @@ export function WorkOrdersList() {
               <DesktopView
                 orders={filteredOrders}
                 isLoading={isLoading}
+                technicians={technicians}
                 getTechnicianName={getTechnicianName}
                 getPurchaseOrderStatus={getPurchaseOrderStatus}
                 onDeleteOrder={handleDeleteWorkOrder}
@@ -456,10 +548,11 @@ function MobileView({
   )
 }
 
-// Desktop View Component (existing table)
+// Desktop View Component — scannable table with hierarchy and hover actions
 function DesktopView({
   orders,
   isLoading,
+  technicians,
   getTechnicianName,
   getPurchaseOrderStatus,
   onDeleteOrder,
@@ -468,6 +561,7 @@ function DesktopView({
 }: {
   orders: WorkOrderWithAsset[]
   isLoading: boolean
+  technicians: Record<string, Profile>
   getTechnicianName: (techId: string | null) => string
   getPurchaseOrderStatus: (poId: string | null) => string
   onDeleteOrder: (order: WorkOrderWithAsset) => void
@@ -493,28 +587,49 @@ function DesktopView({
     )
   }
 
+  function TechnicianCell({ techId }: { techId: string | null }) {
+    const name = getTechnicianName(techId)
+    const tech = techId ? technicians[techId] : null
+    const initials = tech?.nombre && tech?.apellido
+      ? `${tech.nombre[0]}${tech.apellido[0]}`.toUpperCase()
+      : name.slice(0, 2).toUpperCase()
+    return (
+      <div className="flex items-center gap-2">
+        <Avatar className="h-7 w-7 flex-shrink-0 border border-border">
+          <AvatarFallback className="text-xs bg-muted text-muted-foreground">
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+        <span className="truncate text-sm">{name}</span>
+      </div>
+    )
+  }
+
   return (
-    <div className="rounded-md border">
+    <div className="rounded-lg border overflow-hidden">
       <Table>
         <TableHeader>
-          <TableRow>
-            <TableHead className="w-[100px]">OT ID</TableHead>
-            <TableHead>Activo</TableHead>
-            <TableHead>Tipo</TableHead>
-            <TableHead>Prioridad</TableHead>
-            <TableHead>Estado</TableHead>
-            <TableHead>OC</TableHead>
-            <TableHead>Fecha Planificada</TableHead>
-            <TableHead>Asignado A</TableHead>
-            <TableHead className="text-right w-[100px]">Acciones</TableHead>
+          <TableRow className="hover:bg-transparent border-b">
+            <TableHead className="w-[100px] font-semibold text-muted-foreground">OT ID</TableHead>
+            <TableHead className="font-semibold text-muted-foreground">Activo</TableHead>
+            <TableHead className="w-[90px] font-semibold text-muted-foreground">Tipo</TableHead>
+            <TableHead className="w-[90px] font-semibold text-muted-foreground">Prioridad</TableHead>
+            <TableHead className="w-[120px] font-semibold text-muted-foreground">Estado</TableHead>
+            <TableHead className="w-[90px] font-semibold text-muted-foreground">OC</TableHead>
+            <TableHead className="w-[100px] text-right font-semibold text-muted-foreground">Fecha</TableHead>
+            <TableHead className="w-[140px] font-semibold text-muted-foreground">Asignado</TableHead>
+            <TableHead className="w-[56px] text-right font-semibold text-muted-foreground" />
           </TableRow>
         </TableHeader>
         <TableBody>
           {orders.map((order) => (
-            <TableRow key={order.id}>
-              <TableCell className="font-medium">
-                <div className="flex flex-col gap-1">
-                  <span>{order.order_id}</span>
+            <TableRow
+              key={order.id}
+              className="group border-b last:border-0 hover:bg-muted/40 transition-colors"
+            >
+              <TableCell className="py-3 align-middle">
+                <div className="flex flex-col gap-0.5">
+                  <span className="font-medium text-foreground">{order.order_id}</span>
                   {order.incident_id && order.asset_id && (
                     <Badge variant="outline" className="w-fit text-xs" asChild>
                       <Link href={`/activos/${order.asset_id}/incidentes`} className="hover:underline">
@@ -524,56 +639,80 @@ function DesktopView({
                   )}
                 </div>
               </TableCell>
-              <TableCell>
-                {order.asset?.name || "N/A"}
-                {order.asset?.asset_id && (
-                  <span className="text-xs text-muted-foreground ml-1">({order.asset.asset_id})</span>
-                )}
+              <TableCell className="py-3 align-middle">
+                <div className="flex flex-col min-w-0">
+                  <span className="font-medium text-foreground truncate">
+                    {order.asset?.name || "N/A"}
+                  </span>
+                  {order.asset?.asset_id && (
+                    <span className="text-xs text-muted-foreground truncate">{order.asset.asset_id}</span>
+                  )}
+                </div>
               </TableCell>
-              <TableCell>
-                <Badge variant={getTypeVariant(order.type)} className="capitalize">
+              <TableCell className="py-3 align-middle">
+                <Badge variant={getTypeVariant(order.type)} className="capitalize text-xs">
                   {order.type || "N/A"}
                 </Badge>
               </TableCell>
-              <TableCell>
-                <Badge variant={getPriorityVariant(order.priority)} className="capitalize">
-                  {order.priority || "N/A"}
-                </Badge>
+              <TableCell className="py-3 align-middle">
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className={cn(
+                      "h-2 w-2 shrink-0 rounded-full",
+                      getPriorityDotClass(order.priority)
+                    )}
+                    aria-hidden
+                  />
+                  <span className="text-sm capitalize text-muted-foreground">
+                    {order.priority || "N/A"}
+                  </span>
+                </div>
               </TableCell>
-              <TableCell>
-                <Badge variant={getStatusVariant(order.status)} className="capitalize">
-                  {order.status || "N/A"}
-                </Badge>
+              <TableCell className="py-3 align-middle">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "h-2 w-2 shrink-0 rounded-full",
+                      getStatusDotClass(order.status)
+                    )}
+                    aria-hidden
+                  />
+                  <span className="text-sm capitalize">{order.status || "N/A"}</span>
+                </div>
               </TableCell>
-              <TableCell>
+              <TableCell className="py-3 align-middle">
                 {order.purchase_order_id ? (
                   <Badge
                     variant={getPurchaseOrderStatusVariant(getPurchaseOrderStatus(order.purchase_order_id))}
-                    className={getPurchaseOrderStatusClass(getPurchaseOrderStatus(order.purchase_order_id))}
+                    className={cn("text-xs", getPurchaseOrderStatusClass(getPurchaseOrderStatus(order.purchase_order_id)))}
                   >
                     {getPurchaseOrderStatus(order.purchase_order_id)}
                   </Badge>
                 ) : order.type === MaintenanceType.Preventive && order.required_parts ? (
-                  <Badge variant="outline" className="bg-yellow-50 text-yellow-800">
+                  <Badge variant="outline" className="bg-amber-50 text-amber-800 dark:bg-amber-950/50 dark:text-amber-200 text-xs">
                     Pendiente
                   </Badge>
                 ) : (
-                  <span className="text-xs text-muted-foreground">N/A</span>
+                  <span className="text-xs text-muted-foreground">—</span>
                 )}
               </TableCell>
-              <TableCell>
-                {order.planned_date ? formatDate(order.planned_date) : "No planificada"}
+              <TableCell className="py-3 align-middle text-right tabular-nums text-sm text-muted-foreground">
+                {order.planned_date ? formatDateRelative(order.planned_date) : "—"}
               </TableCell>
-              <TableCell>{getTechnicianName(order.assigned_to)}</TableCell>
-              <TableCell className="text-right">
-                <WorkOrderActionsMenu
-                  order={order}
-                  getPurchaseOrderStatus={getPurchaseOrderStatus}
-                  onDeleteOrder={onDeleteOrder}
-                  variant="desktop"
-                  canEdit={canEdit}
-                  canDelete={canDelete}
-                />
+              <TableCell className="py-3 align-middle">
+                <TechnicianCell techId={order.assigned_to} />
+              </TableCell>
+              <TableCell className="py-3 align-middle text-right">
+                <div className="flex justify-end opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+                  <WorkOrderActionsMenu
+                    order={order}
+                    getPurchaseOrderStatus={getPurchaseOrderStatus}
+                    onDeleteOrder={onDeleteOrder}
+                    variant="desktop"
+                    canEdit={canEdit}
+                    canDelete={canDelete}
+                  />
+                </div>
               </TableCell>
             </TableRow>
           ))}

--- a/components/work-orders/workflow-summary-bar.tsx
+++ b/components/work-orders/workflow-summary-bar.tsx
@@ -29,31 +29,47 @@ const cards: {
   key: WorkflowSummaryFilter
   label: string
   icon: typeof Clock
-  accentClass: string
+  /** Left border + icon bg + text: border-l-4, icon container, number/label */
+  borderClass: string
+  iconBgClass: string
+  numberClass: string
+  labelClass: string
 }[] = [
   {
     key: "overdue",
     label: "Vencidas",
     icon: AlertCircle,
-    accentClass: "text-amber-600 bg-amber-50 dark:bg-amber-950/50 ring-amber-400",
+    borderClass: "border-l-4 border-l-red-500",
+    iconBgClass: "bg-red-50 text-red-600 dark:bg-red-950/50 dark:text-red-400",
+    numberClass: "text-red-600 dark:text-red-400",
+    labelClass: "text-red-700/80 dark:text-red-300/80",
   },
   {
     key: "active",
     label: "En curso",
     icon: Clock,
-    accentClass: "text-blue-600 bg-blue-50 dark:bg-blue-950/50 ring-blue-400",
+    borderClass: "border-l-4 border-l-blue-500",
+    iconBgClass: "bg-blue-50 text-blue-600 dark:bg-blue-950/50 dark:text-blue-400",
+    numberClass: "text-blue-600 dark:text-blue-400",
+    labelClass: "text-blue-700/80 dark:text-blue-300/80",
   },
   {
     key: "waiting_po",
     label: "Espera OC",
     icon: Package,
-    accentClass: "text-indigo-600 bg-indigo-50 dark:bg-indigo-950/50 ring-indigo-400",
+    borderClass: "border-l-4 border-l-amber-500",
+    iconBgClass: "bg-amber-50 text-amber-600 dark:bg-amber-950/50 dark:text-amber-400",
+    numberClass: "text-amber-600 dark:text-amber-400",
+    labelClass: "text-amber-700/80 dark:text-amber-300/80",
   },
   {
     key: "today_completed",
     label: "Hoy completadas",
     icon: CheckCircle,
-    accentClass: "text-green-600 bg-green-50 dark:bg-green-950/50 ring-green-400",
+    borderClass: "border-l-4 border-l-green-500",
+    iconBgClass: "bg-green-50 text-green-600 dark:bg-green-950/50 dark:text-green-400",
+    numberClass: "text-green-600 dark:text-green-400",
+    labelClass: "text-green-700/80 dark:text-green-300/80",
   },
 ]
 
@@ -70,20 +86,28 @@ export function WorkflowSummaryBar({
         className
       )}
     >
-      {cards.map(({ key, label, icon: Icon, accentClass }) => {
-        const count = key === "overdue" ? counts.overdue
-          : key === "active" ? counts.active
-          : key === "waiting_po" ? counts.waitingPo
-          : counts.todayCompleted
+      {cards.map(({ key, label, icon: Icon, borderClass, iconBgClass, numberClass, labelClass }) => {
+        const count =
+          key === "overdue"
+            ? counts.overdue
+            : key === "active"
+              ? counts.active
+              : key === "waiting_po"
+                ? counts.waitingPo
+                : counts.todayCompleted
         const isActive = activeFilter === key
+        const isEmpty = count === 0
         return (
           <Card
             key={key}
             role="button"
             tabIndex={0}
             className={cn(
-              "cursor-pointer transition-all hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              isActive && "ring-2 ring-primary shadow-md"
+              "cursor-pointer transition-all duration-200 overflow-hidden",
+              "hover:shadow-md hover:border-muted-foreground/20",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              borderClass,
+              isActive && "ring-2 ring-primary shadow-md border-primary/30"
             )}
             onClick={() => onFilterChange(isActive ? null : key)}
             onKeyDown={(e) => {
@@ -93,23 +117,34 @@ export function WorkflowSummaryBar({
               }
             }}
           >
-            <CardContent className="p-4">
-              <div className="text-center">
+            <CardContent className="p-4 pl-5">
+              <div className="flex items-start gap-4">
                 <div
                   className={cn(
-                    "inline-flex items-center justify-center min-w-[2.5rem] px-2 py-1 rounded-full text-2xl sm:text-3xl font-bold",
-                    count > 0 && key === "overdue"
-                      ? "text-amber-600 bg-amber-50 dark:bg-amber-950/50 ring-2 ring-amber-400"
-                      : count > 0
-                        ? "text-slate-900 dark:text-slate-100"
-                        : "text-slate-400 dark:text-slate-500"
+                    "flex-shrink-0 rounded-lg p-2",
+                    iconBgClass,
+                    isEmpty && "opacity-50"
                   )}
                 >
-                  {count}
+                  <Icon className="h-5 w-5" aria-hidden />
                 </div>
-                <div className="flex items-center justify-center gap-1.5 mt-1.5 text-xs sm:text-sm text-slate-600 dark:text-slate-400">
-                  <Icon className="h-3.5 w-3.5 shrink-0" />
-                  {label}
+                <div className="min-w-0 flex-1">
+                  <div
+                    className={cn(
+                      "text-2xl font-bold tabular-nums tracking-tight",
+                      isEmpty ? "text-muted-foreground" : numberClass
+                    )}
+                  >
+                    {count}
+                  </div>
+                  <p className={cn("text-sm font-medium mt-0.5", isEmpty ? "text-muted-foreground" : labelClass)}>
+                    {label}
+                  </p>
+                  {count > 0 && key === "overdue" && (
+                    <p className="text-xs text-red-600/90 dark:text-red-400/90 mt-1">
+                      Requieren atención
+                    </p>
+                  )}
                 </div>
               </div>
             </CardContent>

--- a/components/work-orders/workflow-summary-bar.tsx
+++ b/components/work-orders/workflow-summary-bar.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import { Card, CardContent } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import { AlertCircle, CheckCircle, Clock, Package } from "lucide-react"
+
+export type WorkflowSummaryFilter =
+  | "overdue"
+  | "active"
+  | "waiting_po"
+  | "today_completed"
+  | null
+
+export interface WorkflowSummaryCounts {
+  overdue: number
+  active: number
+  waitingPo: number
+  todayCompleted: number
+}
+
+export interface WorkflowSummaryBarProps {
+  counts: WorkflowSummaryCounts
+  activeFilter: WorkflowSummaryFilter
+  onFilterChange: (filter: WorkflowSummaryFilter) => void
+  className?: string
+}
+
+const cards: {
+  key: WorkflowSummaryFilter
+  label: string
+  icon: typeof Clock
+  accentClass: string
+}[] = [
+  {
+    key: "overdue",
+    label: "Vencidas",
+    icon: AlertCircle,
+    accentClass: "text-amber-600 bg-amber-50 dark:bg-amber-950/50 ring-amber-400",
+  },
+  {
+    key: "active",
+    label: "En curso",
+    icon: Clock,
+    accentClass: "text-blue-600 bg-blue-50 dark:bg-blue-950/50 ring-blue-400",
+  },
+  {
+    key: "waiting_po",
+    label: "Espera OC",
+    icon: Package,
+    accentClass: "text-indigo-600 bg-indigo-50 dark:bg-indigo-950/50 ring-indigo-400",
+  },
+  {
+    key: "today_completed",
+    label: "Hoy completadas",
+    icon: CheckCircle,
+    accentClass: "text-green-600 bg-green-50 dark:bg-green-950/50 ring-green-400",
+  },
+]
+
+export function WorkflowSummaryBar({
+  counts,
+  activeFilter,
+  onFilterChange,
+  className,
+}: WorkflowSummaryBarProps) {
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4 mb-4 md:mb-6",
+        className
+      )}
+    >
+      {cards.map(({ key, label, icon: Icon, accentClass }) => {
+        const count = key === "overdue" ? counts.overdue
+          : key === "active" ? counts.active
+          : key === "waiting_po" ? counts.waitingPo
+          : counts.todayCompleted
+        const isActive = activeFilter === key
+        return (
+          <Card
+            key={key}
+            role="button"
+            tabIndex={0}
+            className={cn(
+              "cursor-pointer transition-all hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              isActive && "ring-2 ring-primary shadow-md"
+            )}
+            onClick={() => onFilterChange(isActive ? null : key)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault()
+                onFilterChange(isActive ? null : key)
+              }
+            }}
+          >
+            <CardContent className="p-4">
+              <div className="text-center">
+                <div
+                  className={cn(
+                    "inline-flex items-center justify-center min-w-[2.5rem] px-2 py-1 rounded-full text-2xl sm:text-3xl font-bold",
+                    count > 0 && key === "overdue"
+                      ? "text-amber-600 bg-amber-50 dark:bg-amber-950/50 ring-2 ring-amber-400"
+                      : count > 0
+                        ? "text-slate-900 dark:text-slate-100"
+                        : "text-slate-400 dark:text-slate-500"
+                  )}
+                >
+                  {count}
+                </div>
+                <div className="flex items-center justify-center gap-1.5 mt-1.5 text-xs sm:text-sm text-slate-600 dark:text-slate-400">
+                  <Icon className="h-3.5 w-3.5 shrink-0" />
+                  {label}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/docs/plans/WORK_ORDERS_PAGE_UX_REDESIGN.md
+++ b/docs/plans/WORK_ORDERS_PAGE_UX_REDESIGN.md
@@ -1,0 +1,481 @@
+# Work Orders Page UI/UX Redesign Plan
+
+> **Date:** 2026-03-12  
+> **Focus:** Transform the work orders page from a flat, decontextualized list into a workflow-driven, asset-contextual experience so it becomes the **primary** place for work order management.  
+> **Primary file:** [app/ordenes/page.tsx](../../app/ordenes/page.tsx)  
+> **Core component:** [components/work-orders/work-orders-list.tsx](../../components/work-orders/work-orders-list.tsx) (1,025 lines — monolithic)
+
+**Reference formats:** [ACTIVOS_PAGE_UI_UX_AUDIT_DEEPENED.md](./ACTIVOS_PAGE_UI_UX_AUDIT_DEEPENED.md), [COMPRAS_DASHBOARD_HOLISTIC_PLAN.md](./COMPRAS_DASHBOARD_HOLISTIC_PLAN.md)
+
+---
+
+## Enhancement Summary
+
+### Key Goals
+1. **Make `/ordenes` the primary destination** for work order management (not the asset page fallback).
+2. **Asset context and workflow awareness** — show *which equipment*, *what’s blocking*, and *what needs attention*.
+3. **Prioritization and grouping** — by asset (default), by technician, by workflow state.
+4. **Component decomposition** — break the 1,025-line monolith into testable, reusable pieces.
+5. **Mobile parity** — quick filters, swipe actions, skeleton loading, consistent with Compras/Activos patterns.
+
+### Evidence-Based Problem
+- Users **avoid** `/ordenes` and go to `/activos/[id]` to see work orders in context (StatusMaintenanceTab “Trabajos planificados”).
+- Asset detail page provides: asset name, upcoming maintenances, maintenance history, and work orders **in one place**. The órdenes page offers only a flat list with minimal asset prominence.
+- Current list: single `loadWorkOrders()` fetches all OTs; filters (tab + type + search) are client-side only; no plant, no technician filter, no date range, no grouping.
+
+---
+
+## 1. User Personas and Context
+
+### Primary Users
+
+| Persona | Role | Context | Typical Goals |
+|---------|------|---------|---------------|
+| **Supervisor** | Jefe de mantenimiento | Office or floor; triages daily work | “What needs my attention now?” Assign technicians, unblock (PO/quote), approve, track completion. |
+| **Technician** | Técnico/Operador | Field, often mobile | “What’s my next job?” See assigned OTs, complete checklists, log parts. |
+| **Coordinator** | Coordinador de planta | Multi-plant view | “Are we on track? What’s overdue? What’s costing us?” |
+| **Manager** | Gerencia | Office; periodic | KPIs, trends, budget. Low frequency. |
+
+### Usage Context (When/Where/How)
+
+- **Desktop:** Supervisors triaging, assigning, approving; coordinators reviewing by plant/asset. Often alongside calendar and asset list.
+- **Mobile:** Technicians in plant/field — “my OTs”, complete, view PO. One-handed, quick filters.
+- **Entry points:** Sidebar “Órdenes de Trabajo”, dashboard module card, or from asset detail (“Ver todas las OT”).
+
+### Decision Points on This Page
+
+1. **“Do I have critical/overdue work?”** → Currently: scan full list or use “Pendientes” tab (no overdue vs pending distinction).
+2. **“Which OT for this asset?”** → Currently: search by asset name (works) but no grouping by asset.
+3. **“What’s blocked on procurement?”** → Currently: OC column in table; no dedicated “waiting on PO” view.
+4. **“What did we complete today?”** → Currently: “Completadas” tab only; no “today” filter.
+5. **“Create or edit OT?”** → Header “Nueva OT” and row actions exist; flow is clear.
+
+### Information Hierarchy (What Matters First)
+
+| Priority | Content | Current Placement |
+|----------|---------|-------------------|
+| P0 | Overdue / needs attention | **Missing** — no summary |
+| P1 | Active (in progress) | Tab “En Progreso” |
+| P2 | Find by asset / technician | Search only; no asset/technician filters |
+| P3 | OT rows (ID, asset, type, status, OC, date, assigned) | Table / cards |
+| P4 | Type filter (Preventive/Corrective) | One dropdown |
+| P5 | Footer count | “Mostrando X de Y órdenes” |
+
+**Observation:** No workflow summary (overdue, waiting PO, today completed). Tabs are status-based, not action-based. Asset is one column among many instead of a grouping dimension.
+
+---
+
+## 2. What’s Wrong With the Current Page (Evidence-Based)
+
+### 2.1 Code and UX Evidence
+
+| Issue | Evidence |
+|-------|----------|
+| **Flat, decontextualized list** | `WorkOrdersList` renders `filteredOrders` as a single list; no grouping. Asset appears as `order.asset?.name` in a cell/card, not as a grouping header. |
+| **No asset-first entry** | Asset detail (`status-maintenance-tab.tsx`) shows “Trabajos planificados” with asset context and links to ` /ordenes?assetId=…&asset=…`. Órdenes page only uses `assetId`/`asset` for **search prefill** (lines 299–306), not for default grouping or prominent context. |
+| **Monolithic component** | `work-orders-list.tsx` ≈ 1,025 lines: `WorkOrdersList`, `WorkOrderCard`, `MobileView`, `DesktopView`, `loadWorkOrders`, filter state, delete dialog, tab content duplicated 5× (same Mobile/Desktop switch per tab). |
+| **Duplicate tab content** | Lines 443–518: each `TabsContent` (all, pending, approved, inprogress, completed) repeats the same `MobileView`/`DesktopView` with same props. Filtering is shared via `filteredOrders`; only tab value changes filter. |
+| **Limited filters** | Only: search (text), type (Preventive/Corrective), status tabs. No plant, technician, priority, or date range. Compras has Planta, Activo, Tipo, Proveedor, Fechas + chips. |
+| **No workflow summary** | No counts for “overdue”, “waiting on PO”, “completed today”. Compras has `ComprasSummaryRibbon` with pending/approved/validated and alert banner. |
+| **Desktop actions inconsistency** | Mobile card: Ver, Editar, Completar, Ver OC, Eliminar. Desktop table: Ver, Ver Servicio, Incidente, Editar, Generar OC, Ver OC, Ver Checklist, Registrar Mantenimiento, Re-Programar, Cambiar Estado, Eliminar. “Ver Checklist” / “Re-Programar” / “Cambiar Estado” are not links (no `asChild`/`Link`). |
+| **Single bulk fetch** | `loadWorkOrders()` fetches all work orders (no limit), then technicians and PO statuses in separate calls. No pagination; no summary-only query. |
+
+### 2.2 Preferred Flow (Asset Page) vs Órdenes Page
+
+**Asset detail (StatusMaintenanceTab)** gives:
+- Same asset always in context (header).
+- Three cards: Próximos Mantenimientos, Trabajos realizados, **Trabajos planificados** (work orders).
+- In “Trabajos planificados”: type badge, incident link, order_id, description, technician, date, single “Ver Detalles” CTA; “Ver todas (N+)” and “Nueva OT” with `assetId` in query.
+- Empty state: “Ver todas las OT” and “Nueva OT” with `assetId`.
+
+**Órdenes page** gives:
+- No default context; all OTs in one list.
+- Status tabs + type + search; asset only as column/card field.
+- No “overdue” or “waiting PO” or “today” summary.
+
+So users who think “by asset” or “what’s urgent” naturally stay on asset detail. The redesign must bring **asset context** and **workflow summary** to `/ordenes` so it becomes the primary hub.
+
+---
+
+## 3. User Flow Analysis
+
+### Flow A: “Check what’s overdue” (Urgent path)
+
+```
+Land on /ordenes → See tabs + list → (No dedicated overdue view) → Scroll or search
+→ Maybe use “Pendientes” tab → Still mixed with non-overdue
+→ Or go to /activos → Find asset → See overdue in “Próximos Mantenimientos”
+```
+
+**Issues:** No “Overdue” summary or one-click filter. Overdue is not distinguished from “Pendiente” in tab logic (pending = Pending || Quoted only).
+
+### Flow B: “Find OTs for an asset” (Lookup path)
+
+```
+Land on /ordenes → Search by asset name (or arrive with ?assetId= & ?asset=)
+→ List filters to matching OTs → Scan rows/cards
+```
+
+**Issues:** URL params prefill search (good) but no grouping by asset; multiple OTs for same asset appear as separate rows. No “group by asset” default.
+
+### Flow C: “See what’s blocked on PO” (Procurement path)
+
+```
+Land on /ordenes → Scan “OC” column (desktop) or card (mobile) for status
+→ Open dropdown → “Ver OC” if PO exists
+```
+
+**Issues:** No “Waiting on PO” summary or filter; user must scan full list. Compras has “Pendientes” and approval context; OT page has no equivalent.
+
+### Flow D: “My work as technician” (Assignment path)
+
+```
+Land on /ordenes → No “Assigned to me” filter → Search own name or scroll
+→ Find OT → Complete / Ver detalles
+```
+
+**Issues:** No technician filter; no “Mis OT” quick filter on mobile.
+
+### Flow E: “What got done today” (Progress path)
+
+```
+Land on /ordenes → “Completadas” tab → All completed ever, sorted by created_at desc
+→ No “today” filter
+```
+
+**Issues:** No “Completed today” or date range; completed tab is unbounded.
+
+---
+
+## 4. Mobile UX Gap Analysis
+
+### Comparison with Mobile-Optimized Modules
+
+| Feature | Compras | Activos (audit target) | **Órdenes (current)** |
+|---------|---------|-------------------------|------------------------|
+| `useIsMobile()` | Yes | Yes (audit) | **Yes** |
+| Mobile-specific layout | Cards vs table | Grid + cards | **Cards vs table** ✓ |
+| Pull-to-refresh | — | Recommended | **Yes** ✓ |
+| Touch targets 44px+ | Yes | Audit | **Cards ok; dropdown trigger 8×8** |
+| Sticky or top search | — | Recommended | **No** — search in flow |
+| Summary/KPI cards | ComprasSummaryRibbon | 4 summary cards | **None** — only status tabs |
+| Filter bar mobile | Search + Filtros popover | — | **Search + type dropdown** — no popover |
+| Filter chips | Yes | — | **No** |
+| Quick filters (e.g. “Mine”, “Overdue”) | — | — | **No** |
+| Swipe actions on cards | — | — | **No** |
+| Skeleton loading | Yes (list) | Recommended | **Spinner only** |
+
+### Órdenes-Specific Mobile Issues
+
+1. **Tabs on mobile:** Two rows (TabsList 2 cols + 3 Buttons); redundant and space-heavy. Could be one row scrollable or a single “Filter” chip that opens sheet.
+2. **No summary:** Technicians can’t see “3 overdue” or “5 assigned to you” at a glance.
+3. **WorkOrderCard:** Asset and metadata are present but “Ver Detalles” is primary CTA; no swipe for Complete or Ver OC.
+4. **Footer:** “Mostrando X de Y” is good; no “Load more” (all data loaded).
+
+---
+
+## 5. Layout and View Hierarchy
+
+### Current DOM Order (Top to Bottom)
+
+1. `DashboardShell` > `DashboardHeader` (Órdenes de Trabajo, Nueva OT)
+2. `Suspense` > `WorkOrdersList`
+3. `PullToRefresh` > `Card` > `CardContent`:
+   - Search + Type filter (one row)
+   - Tabs (TabsList + on mobile extra row of buttons)
+   - TabsContent (same list for all tabs)
+   - Table (desktop) or card list (mobile)
+4. `CardFooter` (count)
+5. AlertDialog (delete)
+
+### Above-the-Fold (Typical Viewports)
+
+| Viewport | Above fold |
+|----------|------------|
+| 375×667 (mobile) | Header, search, type filter, part of tabs, start of cards |
+| 768×1024 (tablet) | Header, search, type, full tabs, start of table/cards |
+| 1440×900 (desktop) | Header, search, type, tabs, several table rows |
+
+**Observation:** No summary cards; first substantive content is filters then list. Reordering to **summary → filters → list** (like Compras) would support “what needs attention?” before “list”.
+
+### Proposed View Hierarchy (High Level)
+
+1. **Header:** Title, subtitle, Nueva OT, optional view toggle (grouped / flat).
+2. **Workflow summary bar:** 4 cards (Overdue, Active, Waiting on PO, Today completed) with counts; click to filter list.
+3. **Sticky filter bar:** Search, Plant, Asset (optional), Technician, Priority, Date range, Filtros popover (mobile); filter chips when active.
+4. **Primary content:** Grouped by asset (default) or by technician, or flat table; same data, different presentation.
+5. **Footer:** Count and optional “Load more” when paginated.
+
+---
+
+## 6. Proposed Information Architecture
+
+### Current (Broken)
+
+```
+[Header: "Órdenes de Trabajo" + Nueva OT]
+[Tabs: Todas | Pendientes | Aprobadas | En Progreso | Completadas]
+[Search | Tipo dropdown]
+[Flat table or cards]
+```
+
+### Proposed
+
+```
+[Header: "Órdenes de Trabajo" + Nueva OT + (optional) View: Agrupado / Lista]
+
+[WORKFLOW SUMMARY BAR]
+┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐
+│ Overdue    │ │ En curso   │ │ Espera OC  │ │ Hoy        │
+│ (N)        │ │ (N)        │ │ (N)        │ │ (N)        │
+└────────────┘ └────────────┘ └────────────┘ └────────────┘
+
+[FILTER BAR — sticky]
+[Planta ▼] [Técnico ▼] [Prioridad ▼] [Fechas] [Search ______] [Filtros]
+
+[GROUPED VIEW — default]
+┌─ Activo A (plant X) — 3 OT ──────────────────────────────┐
+│  OT-xxx │ Corrective │ Alta │ Juan P. │ Overdue        │
+│  OT-yyy │ Preventive │ Normal │ María │ Hoy            │
+├─ Activo B (plant X) — 2 OT ─────────────────────────────┤
+│  ...                                                    │
+└──────────────────────────────────────────────────────────┘
+
+[FLAT VIEW — optional]
+Sortable table with same columns + workflow badges
+```
+
+---
+
+## 7. Component Decomposition Strategy
+
+### Current Architecture
+
+```
+app/ordenes/page.tsx
+└── WorkOrdersList (1,025 lines)
+    ├── loadWorkOrders (fetch all + technicians + PO statuses)
+    ├── State: workOrders, searchTerm, activeTab, typeFilter, technicians, purchaseOrderStatuses, delete dialog
+    ├── Filter logic (tab + type + search + assetId param)
+    ├── PullToRefresh > Card > Search + Type + Tabs
+    ├── TabsContent × 5 (each: MobileView | DesktopView)
+    ├── MobileView → WorkOrderCard list
+    ├── DesktopView → Table with inline dropdown
+    ├── WorkOrderCard (internal)
+    ├── AlertDialog (delete)
+    └── formatDate, get*Variant helpers
+```
+
+### Target Architecture (Compras-Aligned)
+
+```
+app/ordenes/page.tsx
+└── WorkOrdersModule (orchestrator)
+    ├── WorkOrdersHeader (title, Nueva OT; optional view toggle)
+    ├── useWorkOrdersData (single hook: list, technicians, PO statuses, summary counts, loading)
+    ├── WorkOrdersSummaryRibbon (4 workflow cards with counts; filter toggles)
+    ├── WorkOrdersFilterBar (search, plant, technician, priority, date; mobile: popover + chips)
+    ├── Tabs or filter state (driven by summary + filter bar)
+    └── WorkOrdersList (presentation only)
+        ├── [MOBILE] WorkOrderCard list (optional swipe actions)
+        └── [DESKTOP] Grouped view or flat table
+            ├── WorkOrdersGroupedByAsset (default)
+            ├── WorkOrdersGroupedByTechnician (toggle)
+            └── WorkOrdersTable (flat, sortable)
+```
+
+### Shared / New Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `useWorkOrdersData` | Fetch work orders (paginated or initial batch), technicians, PO statuses; compute summary counts (overdue, in progress, waiting PO, completed today). Expose `orders`, `loadMore`, `isLoading`, `summary`. |
+| `WorkOrdersSummaryRibbon` | Four cards with counts; clicking a card applies/removes that filter. Match `ComprasSummaryRibbon` pattern. |
+| `WorkOrdersFilterBar` | Search + Planta + Técnico + Prioridad + Fechas inline on desktop; mobile: search + “Filtros” popover + filter chips. Match `ComprasFilterBar` (inline vs popover by viewport). |
+| `WorkOrderRowContent` | Single OT row: OT ID, asset (link), type, priority, workflow badge, OC badge, date, technician, actions. Used in table and in grouped view rows. |
+| `WorkOrderActionsMenu` | Dropdown: Ver, Editar, Completar, Ver OC / Generar OC, Ver Servicio, Incidente, Eliminar. Shared by table and card; fix “Ver Checklist” / “Re-Programar” / “Cambiar Estado” (link or remove). |
+| `WorkOrderCard` (refactor) | Keep mobile card; add optional swipe actions; ensure 44px touch targets. |
+| `WorkOrdersGroupedByAsset` | Group `WorkOrderWithAsset[]` by `asset_id` (and optionally plant); render collapsible sections; section header links to `/activos/[id]`. |
+| `WorkOrdersGroupedByTechnician` | Group by `assigned_to`; section header shows technician name and count. |
+
+### File Structure (Target)
+
+```
+components/work-orders/
+├── WorkOrdersModule.tsx           # Orchestrator: data + summary + filters + list
+├── useWorkOrdersData.ts           # Data hook + summary counts
+├── WorkOrdersSummaryRibbon.tsx    # 4 workflow cards
+├── WorkOrdersFilterBar.tsx        # Search, plant, technician, priority, dates; chips
+├── WorkOrdersList.tsx             # Thin: chooses grouped vs table, passes data
+├── views/
+│   ├── WorkOrdersGroupedByAsset.tsx
+│   ├── WorkOrdersGroupedByTechnician.tsx
+│   └── WorkOrdersTable.tsx        # Flat table
+├── WorkOrderRowContent.tsx        # Shared row content
+├── WorkOrderActionsMenu.tsx       # Shared dropdown
+├── WorkOrderCard.tsx              # Mobile card (extract from current)
+└── work-order-badges.ts           # getStatusVariant, getTypeVariant, getPriorityVariant, workflow badge label
+```
+
+---
+
+## 8. Filter Bar Design (ComprasFilterBar Pattern)
+
+- **Desktop:** Inline: Search (flex-1 max-w-sm) + Planta + Técnico + Prioridad + Fechas (Desde/Hasta or range) + “Filtros” popover for secondary filters. Filter chips below when any active; “Limpiar todo”.
+- **Mobile:** Search full width + “Filtros” button (popover with all filters); filter chips below. Same chip design as Compras (e.g. sky-100/sky-800).
+- **Options:** Planta and Técnico from data (assets/plants from work orders or profiles); Prioridad = Critical, High, Normal, Low; Fechas = Overdue, Hoy, Esta semana, Este mes, Custom range.
+- **URL:** Persist `assetId`, `plant`, `technician`, `priority`, `from`, `to` in URL so “Ver todas las OT” from asset detail keeps context.
+
+---
+
+## 9. Data Fetching Improvements
+
+| Current | Proposed |
+|---------|----------|
+| Single query: all work orders, no limit | Initial load: e.g. 50 most recent (or by priority); cursor-based “Load more” or infinite scroll. |
+| No summary query | Lightweight query or in-memory pass for counts: overdue, in progress, waiting PO, completed today. Optionally RPC that returns counts + first page. |
+| Technicians: active + assigned (2 queries) | Keep; ensure assigned are always resolved for list. |
+| PO statuses: by WO IDs (1 query) | Keep; consider including in same graph if using an API layer. |
+| Filters 100% client-side | Keep filters client-side for first phase; later, push plant/date to server for very large datasets. |
+
+---
+
+## 10. Mobile UX Improvements (Concrete)
+
+| Item | Action |
+|------|--------|
+| Summary on mobile | Show WorkOrdersSummaryRibbon (compact 2×2 or horizontal scroll) so “Overdue” and “Mine” are visible. |
+| Quick filters | Chips: “Overdue”, “Mis OT”, “Hoy” (tappable, compose with filter bar). |
+| Swipe actions | On WorkOrderCard: swipe left → “Completar” and “Ver OC” (or “Ver”). |
+| Skeleton | Replace spinner with skeleton cards (3–5) matching WorkOrderCard layout. |
+| Tabs | Replace two-row tabs + buttons with single row (scrollable) or “Filtros” that opens sheet (summary + status). |
+| Touch targets | Ensure dropdown trigger and card actions ≥ 44px; use hitSlop if needed. |
+
+---
+
+## 11. Implementation Phases (Priorities)
+
+### Phase 1: Foundation and Summary (High impact, low risk)
+- [ ] Extract `useWorkOrdersData` (or keep single fetch but add summary counts in hook).
+- [ ] Add `WorkOrdersSummaryRibbon` (4 cards: Overdue, Active, Waiting PO, Today); clicking toggles filter state.
+- [ ] Replace status tabs with summary-driven filter (or keep one “Todas” tab and drive rest from summary).
+- [ ] Add Planta dropdown to filter bar (data from work orders’ assets or plants).
+- [ ] Decompose: move `WorkOrderCard`, `formatDate`, badge helpers to separate files; reduce `work-orders-list.tsx` to < 300 lines.
+- **Effort:** 1–2 sessions.
+
+### Phase 2: Asset-Grouped View and Filter Bar
+- [ ] Build `WorkOrdersFilterBar` (search, plant, technician, priority, dates; mobile popover + chips).
+- [ ] Build `WorkOrdersGroupedByAsset`; default view = grouped; asset header links to `/activos/[id]`.
+- [ ] Add grouping toggle: “Por activo” / “Por técnico” / “Lista” (flat table).
+- [ ] Persist key filters in URL (`assetId`, `plant`, etc.) and read on load.
+- **Effort:** 1–2 sessions.
+
+### Phase 3: Workflow Badges and Actions
+- [ ] Introduce workflow badges (Nueva, Esperando cotización, Aprobada, En progreso, Completada) with short subtitle where useful (e.g. “Esperando OC #123”).
+- [ ] Add “blocked by” hints (unassigned, waiting PO, waiting quote).
+- [ ] Unify and fix desktop actions: extract `WorkOrderActionsMenu`; make “Ver Checklist” / “Re-Programar” / “Cambiar Estado” either links or remove.
+- [ ] Smart date copy: “Vencida hace 3 días”, “Hoy”, “En 2 días”.
+- **Effort:** 1 session.
+
+### Phase 4: Mobile and Performance
+- [ ] Quick filter chips on mobile (Overdue, Mis OT, Hoy).
+- [ ] Skeleton loading for list.
+- [ ] Optional swipe actions on `WorkOrderCard`.
+- [ ] Paginated or “Load more” for list (e.g. 50 per page).
+- **Effort:** 1–2 sessions.
+
+---
+
+## 12. Success Criteria
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Primary entry for OT management | Users prefer `/activos/[id]` | `/ordenes` is primary; asset page links to “Ver todas” for that asset |
+| Time to find a specific OT | Search + scroll | &lt; 5 s with filter + grouped view |
+| Visibility of overdue / blocked | None | Summary bar + one-click filter |
+| Component size | 1 file ≈ 1,025 lines | No file &gt; 250 lines; clear separation of data/filters/list/actions |
+| Mobile: summary + quick filters | None | Summary visible; chips for Overdue / Mine / Today |
+
+---
+
+## 13. Mermaid: User Flow Diagram
+
+```mermaid
+flowchart TD
+    subgraph Entry [Entry Points]
+        A[Sidebar: Órdenes]
+        B[Direct URL /ordenes]
+        C[Asset page: Ver todas las OT]
+    end
+
+    subgraph Page [Órdenes Page]
+        D[Header + Nueva OT]
+        E[Summary Bar]
+        F[Filter Bar]
+        G[List: Grouped or Table]
+    end
+
+    subgraph Decisions [User Decisions]
+        D1{Overdue?}
+        D2{By asset?}
+        D3{Blocked by PO?}
+        D4{My OTs?}
+    end
+
+    subgraph Exits [Exit Points]
+        X1[OT detail /ordenes/id]
+        X2[Asset detail /activos/id]
+        X3[Completar /ordenes/id/completar]
+        X4[Compras /compras]
+    end
+
+    A --> D
+    B --> D
+    C --> D
+
+    D --> E
+    E --> D1
+    E --> D3
+    D1 -->|Click Overdue| F
+    D3 -->|Click Waiting PO| F
+
+    D --> F
+    F --> G
+    G --> D2
+    D2 -->|Asset header| X2
+    D2 -->|Row Ver| X1
+    G --> D4
+    D4 -->|Completar| X3
+    G -->|Ver OC| X4
+```
+
+---
+
+## 14. Industry Patterns (CMMS / Maintenance)
+
+- **Asset-centric triage:** Supervisors think by equipment; grouping by asset (and plant) matches mental model. Default “group by asset” is critical.
+- **Workflow visibility:** “Blocked by” (PO, quote, assignment) is standard in CMMS; summary cards for “overdue” and “waiting PO” reduce cognitive load.
+- **Technician view:** “My work” filter and “assigned to me” quick filter are expected on mobile.
+- **Completion today:** Daily progress (“what we closed today”) supports stand-ups and reporting.
+- **Design alignment:** Summary ribbon (Compras), filter bar + chips (Compras), grouped lists (Activos/checklists) — reuse same patterns for consistency.
+
+---
+
+## 15. References
+
+### Internal
+- [ACTIVOS_PAGE_UI_UX_AUDIT_DEEPENED.md](./ACTIVOS_PAGE_UI_UX_AUDIT_DEEPENED.md) — User flows, mobile gap, layout hierarchy.
+- [COMPRAS_DASHBOARD_HOLISTIC_PLAN.md](./COMPRAS_DASHBOARD_HOLISTIC_PLAN.md) — Data layer, filter bar, table redesign, file structure.
+- [ComprasFilterBar.tsx](../../components/compras/ComprasFilterBar.tsx) — Inline vs popover, chips.
+- [ComprasModule.tsx](../../components/compras/ComprasModule.tsx) — useComprasData, summary ribbon, tabs.
+- [status-maintenance-tab.tsx](../../components/assets/activos-detail/tabs/status-maintenance-tab.tsx) — How work orders are shown in asset context (preferred flow).
+- [types/index.ts](../../types/index.ts) — WorkOrder, WorkOrderWithAsset, WorkOrderStatus, MaintenanceType, ServiceOrderPriority.
+
+### Out of Scope (For Now)
+- Changes to OT detail page (`/ordenes/[id]`) or create/edit flows.
+- New workflow states or approval logic.
+- Real-time subscriptions for OT updates.
+- Offline or PWA-specific behavior.
+
+---
+
+**Next step:** Approve this plan; then implement Phase 1 (foundation, summary bar, filter bar start, decomposition). Iterate with Phase 2 (grouped view, full filter bar) so `/ordenes` becomes the primary work order management page.


### PR DESCRIPTION
## Changes

### Phase 1: UX Redesign
- Decomposed 1,025-line `work-orders-list.tsx` into focused components:
  - `work-order-badges.ts` — shared badge/format helpers
  - `work-order-actions-menu.tsx` — extracted dropdown actions
  - `work-order-card-mobile.tsx` — mobile card component
  - `use-delete-work-order.ts` — delete hook with cleanup
  - `work-order-delete-dialog.tsx` — delete confirmation dialog
  - `workflow-summary-bar.tsx` — 4-card workflow summary
- Replaced status tabs with workflow-centric summary bar (Overdue, Active, Waiting PO, Today)
- Added plant filter dropdown (fetches from /api/plants)
- Added workflow filtering (click summary card to filter list)

### Role-Based Permissions
- Hide 'Nueva OT' button unless `hasCreateAccess(userRole, 'work_orders')`
- MECANICO auto-filtered to see only assigned OTs
- Plant-scoped users auto-filtered to their plant; plant filter hidden
- `canEdit` / `canDelete` props on action menus based on role permissions
- Read-only view for AUXILIAR_COMPRAS and VISUALIZADOR
- OPERADOR blocked by route permission (`work_orders: none`)

### Not Yet (Future Phases)
- Asset-grouped view
- Mobile swipe actions
- Paginated data fetching
- Workflow intelligence (blocking indicators)