### PR TITLE
fix(mobile): allow gallery selection for diesel evidence photos

### DIFF
--- a/components/checklists/smart-photo-upload.tsx
+++ b/components/checklists/smart-photo-upload.tsx
@@ -328,7 +328,6 @@ export function SmartPhotoUpload({
             id={`photo-upload-${itemId}`}
             type="file"
             accept="image/*"
-            capture="environment"
             className="hidden"
             disabled={disabled || uploading}
             onChange={(e) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Diesel registration (and other flows using `SmartPhotoUpload`) needed reliable **camera** and **gallery** on both Android and iOS.

## Changes

1. **First revision:** Removed `capture="environment"` from a single file input so gallery was not forced away on some devices.
2. **Follow-up:** Android often only showed “files” with `accept="image/*"` alone. We now mirror the pattern from `evidence-upload.tsx`: **two explicit actions**:
   - **Tomar foto** → hidden input with `accept="image/*"` and `capture="environment"` (direct camera).
   - **Galería** → hidden input with `accept="image/*"` only (photo library / file picker without capture hint).

## Scope

`SmartPhotoUpload` is used by diesel entry/adjustment/consumption forms and checklist-style evidence; all get the dual-button flow on mobile-friendly layouts (stacked on narrow screens, two columns from `sm` breakpoint up).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ec7b539-5ee3-4384-8a25-8ae0217004f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ec7b539-5ee3-4384-8a25-8ae0217004f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

