### PR TITLE
Gerencial reports: diesel parity, navigation hub, and Ingresos vs gastos access

### DIFF
--- a/app/(dashboard)/dashboard/jun/page.tsx
+++ b/app/(dashboard)/dashboard/jun/page.tsx
@@ -403,7 +403,7 @@ export default function JUNDashboard() {
           </Button>
         }
         shortcuts={[
-          ...reportShortcutsForRole(profile.role).map((s) => ({
+          ...reportShortcutsForRole(profile.role, profile).map((s) => ({
             label: s.label,
             href: s.href,
             icon: <BarChart3 className="h-4 w-4" />,

--- a/app/(dashboard)/dashboard/jun/page.tsx
+++ b/app/(dashboard)/dashboard/jun/page.tsx
@@ -29,7 +29,9 @@ import { cn } from "@/lib/utils"
 import { DashboardModuleLinks } from "@/components/dashboard/dashboard-module-links"
 import { DashboardExecutiveLayout } from "@/components/dashboard/dashboard-executive-layout"
 import { DashboardExecutiveHero } from "@/components/dashboard/dashboard-executive-hero"
+import { reportShortcutsForRole } from "@/lib/reports/executive-dashboard-shortcuts"
 import { DashboardActionStrip } from "@/components/dashboard/dashboard-action-strip"
+import { reportShortcutsForRole } from "@/lib/reports/executive-dashboard-shortcuts"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -401,6 +403,11 @@ export default function JUNDashboard() {
           </Button>
         }
         shortcuts={[
+          ...reportShortcutsForRole(profile.role).map((s) => ({
+            label: s.label,
+            href: s.href,
+            icon: <BarChart3 className="h-4 w-4" />,
+          })),
           { label: "Gestión de personal", href: "/gestion/personal", icon: <Users className="h-4 w-4" /> },
           { label: "Registrar usuario", href: "/gestion/personal?registrar=1", icon: <UserPlus className="h-4 w-4" /> },
           { label: "Asignaciones organizacionales", href: "/gestion/asignaciones", icon: <Target className="h-4 w-4" /> },

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -384,7 +384,7 @@ function DashboardContent() {
           userRole={getRoleDisplayName(profile.role)}
           authLimit={showAuthLimit ? authorizationLimit : undefined}
           shortcuts={[
-            ...reportShortcutsForRole(profile.role).map((s) => ({
+            ...reportShortcutsForRole(profile.role, profile).map((s) => ({
               label: s.label,
               href: s.href,
               icon: <BarChart3Icon className="h-4 w-4" />,

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -44,6 +44,8 @@ import { DashboardExecutiveLayout } from "@/components/dashboard/dashboard-execu
 import { DashboardModuleLinks } from "@/components/dashboard/dashboard-module-links"
 import { DashboardExecutiveKPIs } from "@/components/dashboard/dashboard-executive-kpis"
 import { DashboardExecutiveHero } from "@/components/dashboard/dashboard-executive-hero"
+import { reportShortcutsForRole } from "@/lib/reports/executive-dashboard-shortcuts"
+import { BarChart3 as BarChart3Icon } from "lucide-react"
 
 function DashboardContent() {
   const { 
@@ -381,25 +383,28 @@ function DashboardContent() {
           userName={`${profile.nombre} ${profile.apellido}`.trim()}
           userRole={getRoleDisplayName(profile.role)}
           authLimit={showAuthLimit ? authorizationLimit : undefined}
-          shortcuts={
-            profile.role === 'GERENCIA_GENERAL'
+          shortcuts={[
+            ...reportShortcutsForRole(profile.role).map((s) => ({
+              label: s.label,
+              href: s.href,
+              icon: <BarChart3Icon className="h-4 w-4" />,
+            })),
+            ...(profile.role === 'GERENCIA_GENERAL'
               ? [
-                  { label: 'Reporte Gerencial', href: '/reportes/gerencial', icon: <BarChart3 className="h-4 w-4" /> },
                   { label: 'Compras Alto Valor', href: '/compras?tab=pending', icon: <ShoppingCart className="h-4 w-4" /> },
                   { label: 'Configuración Sistema', href: '/gestion', icon: <Shield className="h-4 w-4" /> },
                 ]
               : profile.role === 'AREA_ADMINISTRATIVA'
-              ? [
-                  { label: 'Compras Pendientes', href: '/compras?tab=pending', icon: <ShoppingCart className="h-4 w-4" /> },
-                  { label: 'Gestionar Personal', href: '/gestion/personal', icon: <Users className="h-4 w-4" /> },
-                  { label: 'Reportes Administrativos', href: '/reportes?type=admin', icon: <BarChart3 className="h-4 w-4" /> },
-                ]
-              : [
-                  { label: 'Incidentes activos', href: '/incidentes', icon: <AlertTriangle className="h-4 w-4" /> },
-                  { label: 'Activos', href: '/activos', icon: <Package className="h-4 w-4" /> },
-                  { label: 'Plan preventivo', href: '/preventivo', icon: <Wrench className="h-4 w-4" /> },
-                ]
-          }
+                ? [
+                    { label: 'Compras Pendientes', href: '/compras?tab=pending', icon: <ShoppingCart className="h-4 w-4" /> },
+                    { label: 'Gestionar Personal', href: '/gestion/personal', icon: <Users className="h-4 w-4" /> },
+                  ]
+                : profile.role === 'GERENTE_MANTENIMIENTO'
+                  ? [
+                      { label: 'Compras pendientes', href: '/compras?tab=pending', icon: <ShoppingCart className="h-4 w-4" /> },
+                    ]
+                  : []),
+          ]}
           modules={
             <DashboardModuleLinks
               modules={moduleCards.map((c) => ({

--- a/app/api/reports/asset-diesel-efficiency/route.ts
+++ b/app/api/reports/asset-diesel-efficiency/route.ts
@@ -2,6 +2,10 @@ import { createClient } from '@supabase/supabase-js'
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { computeAssetDieselEfficiencyMonths } from '@/lib/reports/compute-asset-diesel-efficiency-monthly'
+import {
+  canRecomputeDieselEfficiency,
+  requireReportsApiAccess,
+} from '@/lib/reports/report-api-auth'
 import type { Database } from '@/types/supabase-types'
 
 type PostBody = {
@@ -13,14 +17,9 @@ type PostBody = {
 
 export async function GET(req: NextRequest) {
   try {
-    const supabase = await createServerSupabase()
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const auth = await requireReportsApiAccess()
+    if (!auth.ok) return auth.response
+    const supabase = auth.supabase
 
     const { searchParams } = new URL(req.url)
     const yearMonth = searchParams.get('yearMonth')
@@ -83,13 +82,10 @@ export async function GET(req: NextRequest) {
  */
 export async function POST(req: NextRequest) {
   try {
-    const supabase = await createServerSupabase()
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+    const auth = await requireReportsApiAccess()
+    if (!auth.ok) return auth.response
+    if (!canRecomputeDieselEfficiency(auth.actor)) {
+      return NextResponse.json({ error: 'Sin permiso para recalcular eficiencia' }, { status: 403 })
     }
 
     const body = (await req.json()) as PostBody

--- a/app/api/reports/gerencial/analisis-costos/route.ts
+++ b/app/api/reports/gerencial/analisis-costos/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { unstable_cache } from 'next/cache'
 import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { runCostAnalysis } from '@/lib/reports/cost-analysis-aggregate'
+import { requireReportsApiAccess } from '@/lib/reports/report-api-auth'
 
 export const maxDuration = 120
 
@@ -55,22 +56,20 @@ async function runCostAnalysisCached(params: {
 
 export async function POST(req: NextRequest) {
   try {
+    const auth = await requireReportsApiAccess()
+    if (!auth.ok) return auth.response
+
     const body = await req.json()
     const months: string[] = Array.isArray(body.months) ? body.months : []
     const businessUnitId: string | null = body.businessUnitId || null
     const plantId: string | null = body.plantId || null
-
-    const supabase = await createServerSupabase()
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
 
     const payload = await runCostAnalysisCached({
       months,
       businessUnitId,
       plantId,
       requestHost: req.headers.get('host'),
-      rollupReadUserKey: user?.id ?? 'anonymous',
+      rollupReadUserKey: auth.actor.userId,
     })
 
     return NextResponse.json(payload)

--- a/app/api/reports/gerencial/ingresos-gastos/details/route.ts
+++ b/app/api/reports/gerencial/ingresos-gastos/details/route.ts
@@ -2,10 +2,14 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { getExpenseCategoryById, getExpenseCategoryDisplayName } from '@/lib/constants/expense-categories'
+import { requireIngresosGastosApiAccess } from '@/lib/reports/report-api-auth'
 
 // GET: Fetch manual cost details grouped by department
 export async function GET(req: NextRequest) {
   try {
+    const auth = await requireIngresosGastosApiAccess()
+    if (!auth.ok) return auth.response
+
     const { searchParams } = new URL(req.url)
     const month = searchParams.get('month') // YYYY-MM format
     const plantId = searchParams.get('plantId')
@@ -37,7 +41,7 @@ export async function GET(req: NextRequest) {
     const [year, monthNum] = month.split('-').map(Number)
     const periodMonth = `${year}-${String(monthNum).padStart(2, '0')}-01`
 
-    const supabase = await createServerSupabase()
+    const supabase = auth.supabase
 
     // Get plant code for matching
     const { data: plant } = await supabase

--- a/app/api/reports/gerencial/ingresos-gastos/operational-details/route.ts
+++ b/app/api/reports/gerencial/ingresos-gastos/operational-details/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { runGerencialReport } from '@/lib/reports/run-gerencial-report'
 import {
   aggregateDieselByPlant,
@@ -9,17 +8,13 @@ import {
   type ManttoOperationalDetails,
 } from '@/lib/reports/ingresos-gastos-operational-details'
 import type { AnomalyFlags } from '@/components/reports/diesel-efficiency/types'
+import { requireReportsApiAccess } from '@/lib/reports/report-api-auth'
 
 export async function GET(req: NextRequest) {
   try {
-    const supabase = await createServerSupabase()
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+    const auth = await requireReportsApiAccess()
+    if (!auth.ok) return auth.response
+    const supabase = auth.supabase
 
     const { searchParams } = new URL(req.url)
     const month = searchParams.get('month')

--- a/app/api/reports/gerencial/ingresos-gastos/refresh-materialized-views/route.ts
+++ b/app/api/reports/gerencial/ingresos-gastos/refresh-materialized-views/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { createClient } from '@supabase/supabase-js'
+import { requireIngresosGastosApiAccess } from '@/lib/reports/report-api-auth'
 
 /**
  * Refresh materialized views in the cotizador database
@@ -17,14 +17,8 @@ import { createClient } from '@supabase/supabase-js'
  */
 export async function POST(req: NextRequest) {
   try {
-    // Check authentication against maintenance-dashboard database
-    // (users don't have profiles in cotizador, so we only check here)
-    const supabase = await createServerSupabase()
-    const { data: { user }, error: authError } = await supabase.auth.getUser()
-    
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
+    const auth = await requireIngresosGastosApiAccess()
+    if (!auth.ok) return auth.response
 
     // Check if COTIZADOR credentials are configured
     if (!process.env.COTIZADOR_SUPABASE_URL || !process.env.COTIZADOR_SUPABASE_SERVICE_ROLE_KEY) {

--- a/app/api/reports/gerencial/ingresos-gastos/refresh-view/route.ts
+++ b/app/api/reports/gerencial/ingresos-gastos/refresh-view/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { createClient } from '@supabase/supabase-js'
 import { cotizadorUsesFifoFinancialPipeline } from '@/lib/reports/cotizador-financial-unified-view'
+import { requireIngresosGastosApiAccess } from '@/lib/reports/report-api-auth'
 
 /**
  * Refresh historical financial analysis data for a specific month
@@ -22,6 +23,9 @@ type Body = {
 
 export async function POST(req: NextRequest) {
   try {
+    const auth = await requireIngresosGastosApiAccess()
+    if (!auth.ok) return auth.response
+
     const { month } = (await req.json()) as Body
 
     if (!month) {

--- a/app/api/reports/gerencial/ingresos-gastos/route.ts
+++ b/app/api/reports/gerencial/ingresos-gastos/route.ts
@@ -1,20 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { runIngresosGastosPost } from '@/lib/reports/ingresos-gastos-compute'
+import { requireIngresosGastosApiAccess } from '@/lib/reports/report-api-auth'
 
 /** Cold full compute can exceed the default 10s function limit on Vercel. */
 export const maxDuration = 120
 
 export async function POST(req: NextRequest) {
   try {
+    const auth = await requireIngresosGastosApiAccess()
+    if (!auth.ok) return auth.response
+
     const body = await req.json()
-    const supabase = await createServerSupabase()
     const {
       data: { user },
-    } = await supabase.auth.getUser()
+    } = await auth.supabase.auth.getUser()
     const payload = await runIngresosGastosPost({
       body,
-      supabase,
+      supabase: auth.supabase,
       requestHost: req.headers.get('host'),
       rollupReadUserKey: user?.id ?? 'anonymous',
     })

--- a/app/api/reports/gerencial/route.ts
+++ b/app/api/reports/gerencial/route.ts
@@ -3,12 +3,17 @@ import {
   runGerencialReport,
   type GerencialReportBody,
 } from '@/lib/reports/run-gerencial-report'
+import { requireReportsApiAccess } from '@/lib/reports/report-api-auth'
 
 export async function POST(req: NextRequest) {
   try {
+    const auth = await requireReportsApiAccess()
+    if (!auth.ok) return auth.response
+
     const body = (await req.json()) as GerencialReportBody
     const data = await runGerencialReport(body, {
       requestHost: req.headers.get('host'),
+      supabase: auth.supabase,
     })
     return NextResponse.json(data)
   } catch (e: unknown) {

--- a/app/api/reports/gerencial/scope-filters/route.ts
+++ b/app/api/reports/gerencial/scope-filters/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import { requireReportsApiAccess } from '@/lib/reports/report-api-auth'
+
+/** BU/plant pickers for reports that must not call ingresos-gastos (GG/JUN only). */
+export async function GET() {
+  const auth = await requireReportsApiAccess()
+  if (!auth.ok) return auth.response
+
+  const { supabase } = auth
+  const [{ data: businessUnits, error: buError }, { data: plants, error: plantError }] =
+    await Promise.all([
+      supabase.from('business_units').select('id, name, code').order('name'),
+      supabase
+        .from('plants')
+        .select('id, name, code, business_unit_id')
+        .order('name'),
+    ])
+
+  if (buError || plantError) {
+    console.error('[scope-filters]', buError ?? plantError)
+    return NextResponse.json(
+      { error: buError?.message ?? plantError?.message ?? 'Error al cargar filtros' },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({
+    businessUnits: businessUnits ?? [],
+    plants: plants ?? [],
+  })
+}

--- a/app/reportes/gerencial/analisis-costos/analisis-costos-header.tsx
+++ b/app/reportes/gerencial/analisis-costos/analisis-costos-header.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useAuthZustand } from '@/hooks/use-auth-zustand'
+import { canAccessIngresosGastosReport } from '@/lib/reports/reports-catalog'
+
+export function AnalisisCostosHeader() {
+  const { profile } = useAuthZustand()
+  const showIngresosLink = profile ? canAccessIngresosGastosReport(profile) : false
+
+  return (
+    <div className="space-y-1.5">
+      <Button variant="outline" size="sm" asChild className="w-fit">
+        <Link
+          href={
+            showIngresosLink
+              ? '/reportes/gerencial/ingresos-gastos'
+              : '/reportes/gerencial'
+          }
+        >
+          <ArrowLeft className="mr-2 h-3.5 w-3.5" />
+          {showIngresosLink ? 'Ingresos vs Gastos' : 'Reporte gerencial'}
+        </Link>
+      </Button>
+      <h1
+        className="font-bold tracking-tight"
+        style={{ fontSize: 'clamp(1.75rem, 3vw, 2.5rem)' }}
+      >
+        Centro de mando financiero
+      </h1>
+      <p className="max-w-2xl text-sm text-muted-foreground">
+        Ingresos, costos y rentabilidad — investigación interactiva. Navegue del resumen al
+        detalle de cada planta en un clic.
+      </p>
+    </div>
+  )
+}

--- a/app/reportes/gerencial/analisis-costos/page.tsx
+++ b/app/reportes/gerencial/analisis-costos/page.tsx
@@ -1,31 +1,11 @@
-'use client'
-
-import Link from 'next/link'
-import { ArrowLeft } from 'lucide-react'
-import { Button } from '@/components/ui/button'
 import { CostAnalysisDashboard } from '@/components/reports/cost-analysis/cost-analysis-dashboard'
+import { AnalisisCostosHeader } from './analisis-costos-header'
 
 export default function AnalisisCostosPage() {
   return (
     <div className="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-1.5">
-          <Button variant="outline" size="sm" asChild className="w-fit">
-            <Link href="/reportes/gerencial/ingresos-gastos">
-              <ArrowLeft className="mr-2 h-3.5 w-3.5" />
-              Ingresos vs Gastos
-            </Link>
-          </Button>
-          <h1
-            className="font-bold tracking-tight"
-            style={{ fontSize: 'clamp(1.75rem, 3vw, 2.5rem)' }}
-          >
-            Centro de mando financiero
-          </h1>
-          <p className="max-w-2xl text-sm text-muted-foreground">
-            Ingresos, costos y rentabilidad — investigación interactiva. Navegue del resumen al detalle de cada planta en un clic.
-          </p>
-        </div>
+        <AnalisisCostosHeader />
       </div>
 
       <CostAnalysisDashboard />

--- a/app/reportes/gerencial/ingresos-gastos/layout.tsx
+++ b/app/reportes/gerencial/ingresos-gastos/layout.tsx
@@ -1,0 +1,5 @@
+import { IngresosGastosAccessGuard } from '@/components/reports/ingresos-gastos-access-guard'
+
+export default function IngresosGastosLayout({ children }: { children: React.ReactNode }) {
+  return <IngresosGastosAccessGuard>{children}</IngresosGastosAccessGuard>
+}

--- a/app/reportes/gerencial/page.tsx
+++ b/app/reportes/gerencial/page.tsx
@@ -223,7 +223,8 @@ export default function GerencialReportPage() {
     return list.filter(a =>
       (a.hours_worked || 0) > 0 ||
       (a.kilometers_worked || 0) > 0 ||
-      (a.diesel_liters || 0) > 0
+      (a.diesel_liters || 0) > 0 ||
+      (a.maintenance_cost || 0) > 0
     )
   }, [data?.assets, hideZero])
 
@@ -458,7 +459,7 @@ export default function GerencialReportPage() {
                   onChange={(e) => setHideZero(e.target.checked)}
                   className="rounded"
                 />
-                <span className="text-sm">Ocultar activos sin horas y sin diésel</span>
+                <span className="text-sm">Ocultar activos sin diésel, horas ni gasto de mantenimiento</span>
               </label>
             </div>
 
@@ -479,7 +480,11 @@ export default function GerencialReportPage() {
                 <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
                 {loading ? 'Cargando...' : 'Actualizar'}
               </Button>
-              <Button variant="outline">
+              <Button
+                variant="outline"
+                title="Informe ejecutivo para imprimir o PDF"
+                onClick={() => router.push('/reportes/gerencial/informe-ejecutivo')}
+              >
                 <Download className="w-4 h-4" />
               </Button>
             </div>
@@ -1090,7 +1095,10 @@ export default function GerencialReportPage() {
                 Análisis Detallado por Activo
               </CardTitle>
               <CardDescription>
-                Rendimiento y costos a nivel de equipo individual - {assetsFiltered.length || 0} activos
+                Rendimiento y costos a nivel de equipo individual — {assetsFiltered.length || 0} activos
+                {hideZero && (data?.assets?.length || 0) > assetsFiltered.length
+                  ? ` (tabla filtrada; totales del periodo incluyen ${data?.assets?.length} activos)`
+                  : ''}
               </CardDescription>
             </CardHeader>
             <CardContent>

--- a/app/reportes/gerencial/page.tsx
+++ b/app/reportes/gerencial/page.tsx
@@ -26,6 +26,8 @@ import {
   FileText
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { useAuthZustand } from '@/hooks/use-auth-zustand'
+import { canAccessIngresosGastosReport } from '@/lib/reports/reports-catalog'
 import {
   BarChart,
   Bar,
@@ -142,6 +144,8 @@ type ReportData = {
 
 export default function GerencialReportPage() {
   const router = useRouter()
+  const { profile } = useAuthZustand()
+  const showIngresosGastos = profile ? canAccessIngresosGastosReport(profile) : false
   const [loading, setLoading] = useState(true)
   const [data, setData] = useState<ReportData | null>(null)
   const [dateFrom, setDateFrom] = useState<string>('')
@@ -374,10 +378,12 @@ export default function GerencialReportPage() {
             <TrendingUp className="w-4 h-4 mr-2" />
             Análisis de Costos
           </Button>
-          <Button onClick={() => router.push('/reportes/gerencial/ingresos-gastos')}>
-            <FileText className="w-4 h-4 mr-2" />
-            Ingresos vs Gastos
-          </Button>
+          {showIngresosGastos && (
+            <Button onClick={() => router.push('/reportes/gerencial/ingresos-gastos')}>
+              <FileText className="w-4 h-4 mr-2" />
+              Ingresos vs Gastos
+            </Button>
+          )}
           <Button variant="secondary" onClick={() => router.push('/reportes/eficiencia-diesel')}>
             <Fuel className="w-4 h-4 mr-2" />
             Eficiencia diésel

--- a/app/reportes/layout.tsx
+++ b/app/reportes/layout.tsx
@@ -1,0 +1,10 @@
+import { ReportsSubNav } from '@/components/reports/reports-subnav'
+
+export default function ReportesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col min-h-0">
+      <ReportsSubNav />
+      <div className="flex-1">{children}</div>
+    </div>
+  )
+}

--- a/app/reportes/page.tsx
+++ b/app/reportes/page.tsx
@@ -1,34 +1,21 @@
-import type { Metadata } from "next"
-import { Button } from "@/components/ui/button"
-import { DashboardHeader } from "@/components/dashboard/dashboard-header"
-import { DashboardShell } from "@/components/dashboard/dashboard-shell"
-import { ExecutiveReport } from "@/components/analytics/executive-report"
-import { FileDown, Share } from "lucide-react"
+import type { Metadata } from 'next'
+import { DashboardHeader } from '@/components/dashboard/dashboard-header'
+import { DashboardShell } from '@/components/dashboard/dashboard-shell'
+import { ReportsHub } from '@/components/reports/reports-hub'
 
 export const metadata: Metadata = {
-  title: "Reportes | Sistema de Gestión de Mantenimiento",
-  description: "Dashboard analítico y reportes",
+  title: 'Centro de reportes | Sistema de Gestión de Mantenimiento',
+  description: 'Acceso a reportes gerenciales, eficiencia diésel e informes de mantenimiento',
 }
 
 export default function ReportsPage() {
   return (
     <DashboardShell>
       <DashboardHeader
-        heading="Dashboard Analítico y Reportes"
-        text="Visualiza indicadores clave y genera reportes personalizados."
-      >
-        <div className="flex gap-2">
-          <Button variant="outline">
-            <Share className="mr-2 h-4 w-4" />
-            Compartir
-          </Button>
-          <Button>
-            <FileDown className="mr-2 h-4 w-4" />
-            Exportar
-          </Button>
-        </div>
-      </DashboardHeader>
-      <ExecutiveReport />
+        heading="Centro de reportes"
+        text="Reportes gerenciales, informe de mantenimiento, ingresos-gastos y eficiencia diésel en un solo lugar."
+      />
+      <ReportsHub />
     </DashboardShell>
   )
 }

--- a/components/auth/role-provider.tsx
+++ b/components/auth/role-provider.tsx
@@ -5,6 +5,7 @@ import { useRouter, usePathname } from "next/navigation"
 import { useAuthZustand } from "@/hooks/use-auth-zustand"
 import { canAccessRoute } from "@/lib/auth/role-permissions"
 import { effectiveRoleForPermissions } from "@/lib/auth/role-model"
+import { canAccessReportPath } from "@/lib/reports/reports-catalog"
 
 /** Routes where we must not require a loaded profile (password recovery, etc.). */
 function isAuthFlowRoute(pathname: string): boolean {
@@ -37,7 +38,11 @@ export function RoleProvider({ children }: { children: React.ReactNode }) {
     const permissionRoleKey =
       effectiveRoleForPermissions(profile) ?? profile.business_role ?? profile.role ?? null
 
-    if (profile && permissionRoleKey && !canAccessRoute(permissionRoleKey, pathname)) {
+    const moduleOk =
+      profile && permissionRoleKey ? canAccessRoute(permissionRoleKey, pathname) : true
+    const reportPathOk = profile ? canAccessReportPath(profile, pathname) : true
+
+    if (profile && permissionRoleKey && (!moduleOk || !reportPathOk)) {
       router.push(`/dashboard?error=access_denied&module=${pathname.split('/')[1]}`)
     }
   }, [pathname, profile, loading, user, router])

--- a/components/dashboard/dashboard-executive-kpis.tsx
+++ b/components/dashboard/dashboard-executive-kpis.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { Fuel, TrendingDown, TrendingUp, Wrench } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useDashboardMaintenanceCost } from "@/hooks/useDashboardMaintenanceCost"
+import { useAuthZustand } from "@/hooks/use-auth-zustand"
 import { useDashboardApprovalQueue } from "@/hooks/useDashboardApprovalQueue"
 import { DashboardApprovalQueue } from "./dashboard-approval-queue"
 
@@ -138,7 +139,8 @@ function CostAndQueueView({
   queueTitle: string
   hideStageLabel?: boolean
 }) {
-  const { current, lastMonth, isLoading: costLoading } = useDashboardMaintenanceCost()
+  const { profile } = useAuthZustand()
+  const { current, lastMonth, isLoading: costLoading } = useDashboardMaintenanceCost(profile ?? undefined)
   const {
     items,
     approvalContext,

--- a/components/reports/cost-analysis/cost-analysis-dashboard.tsx
+++ b/components/reports/cost-analysis/cost-analysis-dashboard.tsx
@@ -130,7 +130,7 @@ export function CostAnalysisDashboard() {
     } catch {
       /* ignore */
     }
-  }, [focusMonth, monthTo, rangeMode])
+  }, [])
 
   const requestFilterOptions = useCallback(() => {
     if (!filterOptionsLoaded.current) void refreshFilters()

--- a/components/reports/cost-analysis/cost-analysis-dashboard.tsx
+++ b/components/reports/cost-analysis/cost-analysis-dashboard.tsx
@@ -117,16 +117,14 @@ export function CostAnalysisDashboard() {
   }, [monthPreset])
 
   const refreshFilters = useCallback(async () => {
-    const monthKey = rangeMode === 'month' ? focusMonth : monthTo
     try {
-      const r = await fetch('/api/reports/gerencial/ingresos-gastos', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ month: monthKey, skipPreviousMonth: true }),
-      })
+      const r = await fetch('/api/reports/gerencial/scope-filters')
       const j = await r.json()
-      if (r.ok && j.filters) {
-        setFilterOptions(j.filters as FilterOptions)
+      if (r.ok && j.businessUnits && j.plants) {
+        setFilterOptions({
+          businessUnits: j.businessUnits as FilterOptions['businessUnits'],
+          plants: j.plants as FilterOptions['plants'],
+        })
         filterOptionsLoaded.current = true
       }
     } catch {

--- a/components/reports/executive-analytical-report/executive-analytical-report-client.tsx
+++ b/components/reports/executive-analytical-report/executive-analytical-report-client.tsx
@@ -99,7 +99,7 @@ export function ExecutiveAnalyticalReportClient() {
   const [dateTo, setDateTo] = useState('')
   const [businessUnitId, setBusinessUnitId] = useState('')
   const [plantId, setPlantId] = useState('')
-  /** Default false: gerencial's "hide zero" drops assets with no diesel/hours even if they have maintenance cost in period. */
+  /** Default false: keep assets with maintenance spend even when diesel/hours are zero. */
   const [hideZero, setHideZero] = useState(false)
   const [loading, setLoading] = useState(false)
   const [raw, setRaw] = useState<GerencialJson | null>(null)
@@ -347,7 +347,7 @@ export function ExecutiveAnalyticalReportClient() {
               onCheckedChange={(c) => setHideZero(c === true)}
             />
             <Label htmlFor="er-hide" className="text-sm font-normal cursor-pointer">
-              Ocultar activos sin actividad
+              Ocultar activos sin diésel, horas ni gasto de mantenimiento
             </Label>
           </div>
         </div>
@@ -382,8 +382,39 @@ export function ExecutiveAnalyticalReportClient() {
           <section className="executive-report-avoid-break space-y-8">
             <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
               <h2 className="text-xl font-semibold tracking-tight text-[#111]">Métricas generales</h2>
-              <p className="text-xs text-[#525252]">Totales según reporte gerencial del periodo.</p>
+              <p className="text-xs text-[#525252]">
+                Totales según reporte gerencial. L/h y km operativos: misma política que{' '}
+                <Link href="/reportes/eficiencia-diesel" className="underline text-[#404040]">
+                  Eficiencia diésel
+                </Link>
+                .
+              </p>
             </div>
+            {rollup.unallocated_maintenance > 0.01 && (
+              <div
+                className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950"
+                role="status"
+              >
+                <p className="font-medium">Gasto de mantenimiento sin asignar a activo</p>
+                <p className="mt-1 tabular-nums">
+                  {fmtMoneyFull(rollup.unallocated_maintenance)} no está en el desglose por equipo (POs sin orden de
+                  trabajo o sin activo). Revise compras y asignación.
+                </p>
+              </div>
+            )}
+            {Math.abs(
+              rollup.summary.total_preventive +
+                rollup.summary.total_corrective -
+                rollup.summary.total_maintenance
+            ) > 0.02 && (
+              <div
+                className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950"
+                role="status"
+              >
+                La suma preventivo + correctivo no coincide con el gasto total de mantenimiento; revise POs sin OT o
+                clasificación de órdenes.
+              </div>
+            )}
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-8 md:gap-x-10 items-start">
               <Kpi
                 value={shortMoneyK(rollup.summary.total_maintenance)}
@@ -439,8 +470,8 @@ export function ExecutiveAnalyticalReportClient() {
               <div className="rounded-lg border border-[var(--er-border)] bg-white p-6">
                 <h3 className="text-sm font-semibold text-[#111] mb-1">Operación</h3>
                 <p className="text-xs text-[#525252] mb-4">
-                  Horas operativas: horómetro en consumos, checklists completados y/o horas por transacción — el mayor
-                  por activo.
+                  Horas y km confiables: curva fusionada de horómetro diésel y checklist (con topes); si no hay curva, se
+                  usa la suma de hours_consumed / kilometers_consumed por consumo — igual que Eficiencia diésel.
                 </p>
                 <ul className="space-y-3 text-sm text-[#525252]">
                   <li>
@@ -453,10 +484,12 @@ export function ExecutiveAnalyticalReportClient() {
                     Equipos en el análisis:{' '}
                     <span className="text-[#111] font-medium">{rollup.summary.asset_count} unidades</span>
                   </li>
-                  <li title="Indicador pendiente de definición en el sistema">
-                    Cobertura de horas: <span className="text-[#111] font-medium">N/D</span>
-                    <span className="block text-xs mt-1 text-[#737373]">
-                      Métrica por definir (fórmula operativa pendiente).
+                  <li>
+                    Activos con horas &gt; 0:{' '}
+                    <span className="text-[#111] font-medium tabular-nums">
+                      {hoursAttr?.assets_with_positive_hours != null
+                        ? `${hoursAttr.assets_with_positive_hours} / ${rollup.summary.asset_count}`
+                        : '—'}
                     </span>
                   </li>
                 </ul>
@@ -571,10 +604,9 @@ export function ExecutiveAnalyticalReportClient() {
                   Distribución de horas operativas
                 </h2>
                 <p className="text-xs text-[#525252] mt-1 max-w-2xl leading-relaxed">
-                  Por activo se usa el mayor entre: avance de horómetro en consumos de diésel, lecturas de horas en
-                  checklists completados, y la suma de <span className="whitespace-nowrap">hours_consumed</span> por
-                  transacción. Así se alinea con el reporte gerencial y el resumen por activo; no sustituye un odómetro
-                  oficial si faltan lecturas.
+                  Horas y km por activo siguen la política de Eficiencia diésel: curva fusionada horómetro + checklist;
+                  si la curva es cero, suma de <span className="whitespace-nowrap">hours_consumed</span> /{' '}
+                  <span className="whitespace-nowrap">kilometers_consumed</span> en consumos del periodo.
                 </p>
               </div>
               <div className="shrink-0 text-left sm:text-right">
@@ -865,8 +897,12 @@ export function ExecutiveAnalyticalReportClient() {
                     <dd className="font-medium text-right text-[#111]">7 tipos</dd>
                   </div>
                   <div className="flex justify-between gap-4">
-                    <dt className="text-[#525252]">Cobertura horas</dt>
-                    <dd className="font-medium text-right text-[#111]">N/D</dd>
+                    <dt className="text-[#525252]">Activos con horas</dt>
+                    <dd className="font-medium text-right text-[#111] tabular-nums">
+                      {hoursAttr?.assets_with_positive_hours != null
+                        ? `${hoursAttr.assets_with_positive_hours} / ${rollup.summary.asset_count}`
+                        : '—'}
+                    </dd>
                   </div>
                   <div className="flex justify-between gap-4">
                     <dt className="text-[#525252]">Fuente</dt>
@@ -874,8 +910,11 @@ export function ExecutiveAnalyticalReportClient() {
                   </div>
                 </dl>
                 <p className="mt-4 text-xs text-[#737373] leading-relaxed border-t border-[var(--er-border)] pt-3">
-                  Horas y ratios que las usan siguen la misma regla que el reporte gerencial: horómetro, checklist y/o
-                  hours_consumed por consumo.
+                  L/h y L/km en gerencial e informe coinciden con{' '}
+                  <Link href="/reportes/eficiencia-diesel" className="underline">
+                    Eficiencia diésel
+                  </Link>{' '}
+                  (horas/km confiables por activo).
                 </p>
               </div>
             </div>

--- a/components/reports/ingresos-gastos-access-guard.tsx
+++ b/components/reports/ingresos-gastos-access-guard.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuthZustand } from '@/hooks/use-auth-zustand'
+import { canAccessIngresosGastosReport } from '@/lib/reports/reports-catalog'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import Link from 'next/link'
+
+export function IngresosGastosAccessGuard({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const { profile, isLoading } = useAuthZustand()
+  const allowed = profile ? canAccessIngresosGastosReport(profile) : false
+
+  useEffect(() => {
+    if (!isLoading && profile && !allowed) {
+      router.replace('/reportes?error=ingresos_gastos_denied')
+    }
+  }, [isLoading, profile, allowed, router])
+
+  if (isLoading || !profile) {
+    return <p className="p-6 text-sm text-muted-foreground">Verificando permisos…</p>
+  }
+
+  if (!allowed) {
+    return (
+      <Card className="mx-4 my-8 max-w-lg border-amber-200 bg-amber-50">
+        <CardHeader>
+          <CardTitle className="text-base text-amber-950">Acceso restringido</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-amber-900">
+          <p>
+            El reporte <strong>Ingresos vs gastos</strong> solo está disponible para{' '}
+            <strong>Gerencia General</strong> y <strong>Jefe de Unidad de Negocio</strong>.
+          </p>
+          <Button variant="outline" asChild>
+            <Link href="/reportes">Volver al centro de reportes</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return <>{children}</>
+}

--- a/components/reports/reports-hub.tsx
+++ b/components/reports/reports-hub.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import Link from 'next/link'
+import { useAuthZustand } from '@/hooks/use-auth-zustand'
+import {
+  filterReportsForProfile,
+  GERENCIAL_METRICS_SPEC,
+  type ReportCatalogEntry,
+} from '@/lib/reports/reports-catalog'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { BarChart3, ChevronRight, Fuel, FileText, Wrench } from 'lucide-react'
+
+function groupIcon(group: ReportCatalogEntry['group']) {
+  switch (group) {
+    case 'gerencial':
+      return BarChart3
+    case 'operativo':
+      return Fuel
+    default:
+      return FileText
+  }
+}
+
+export function ReportsHub() {
+  const { profile, ui } = useAuthZustand()
+  const entries = profile ? filterReportsForProfile(profile) : []
+
+  if (!profile) {
+    return <p className="text-sm text-muted-foreground">Cargando permisos…</p>
+  }
+
+  if (!ui.shouldShowInNavigation('reports')) {
+    return (
+      <Card className="border-amber-200 bg-amber-50">
+        <CardHeader>
+          <CardTitle className="text-base text-amber-950">Sin acceso a reportes</CardTitle>
+          <CardDescription className="text-amber-900/80">
+            Tu rol no incluye el módulo de reportes. Si necesitas acceso, contacta a Gerencia General o
+            Administración.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  const gerencial = entries.filter((e) => e.group === 'gerencial')
+  const operativo = entries.filter((e) => e.group === 'operativo')
+  const legacy = entries.filter((e) => e.group === 'legacy')
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold tracking-tight">Reportes gerenciales</h2>
+        <p className="text-sm text-muted-foreground max-w-3xl">
+          Paquete financiero y de mantenimiento. Las métricas de diésel (L/h, L/km) siguen la misma política que{' '}
+          <Link href="/reportes/eficiencia-diesel" className="underline font-medium text-foreground">
+            Eficiencia diésel
+          </Link>
+          .
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {gerencial.map((entry) => (
+            <ReportCard key={entry.id} entry={entry} />
+          ))}
+        </div>
+      </section>
+
+      {operativo.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold tracking-tight">Operativos</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {operativo.map((entry) => (
+              <ReportCard key={entry.id} entry={entry} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {legacy.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold tracking-tight">Otros</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {legacy.map((entry) => (
+              <ReportCard key={entry.id} entry={entry} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Wrench className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Definición de métricas (gerencial)
+          </h2>
+        </div>
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50 text-left">
+                <th className="p-3 font-medium">Métrica</th>
+                <th className="p-3 font-medium">Origen</th>
+                <th className="p-3 font-medium hidden md:table-cell">Alineación</th>
+              </tr>
+            </thead>
+            <tbody>
+              {GERENCIAL_METRICS_SPEC.map((row) => (
+                <tr key={row.id} className="border-b last:border-0">
+                  <td className="p-3 font-medium">{row.label}</td>
+                  <td className="p-3 text-muted-foreground">{row.source}</td>
+                  <td className="p-3 text-muted-foreground hidden md:table-cell">
+                    {row.alignedWith ?? '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function ReportCard({ entry }: { entry: ReportCatalogEntry }) {
+  const Icon = groupIcon(entry.group)
+  return (
+    <Link href={entry.href} className="block group">
+      <Card className="h-full transition-shadow hover:shadow-md hover:border-primary/30">
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <Icon className="h-4 w-4" />
+            </div>
+            <ChevronRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 mt-1" />
+          </div>
+          <CardTitle className="text-base">{entry.label}</CardTitle>
+          <CardDescription className="text-sm leading-relaxed">{entry.description}</CardDescription>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <span className="text-xs font-medium text-primary">Abrir reporte →</span>
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/components/reports/reports-subnav.tsx
+++ b/components/reports/reports-subnav.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useAuthZustand } from '@/hooks/use-auth-zustand'
+import {
+  filterReportsForProfile,
+  reportEntryMatchesPath,
+  type ReportCatalogEntry,
+} from '@/lib/reports/reports-catalog'
+import { cn } from '@/lib/utils'
+
+type Props = {
+  className?: string
+}
+
+function groupLabel(group: ReportCatalogEntry['group']): string {
+  switch (group) {
+    case 'gerencial':
+      return 'Gerencial'
+    case 'operativo':
+      return 'Operativo'
+    case 'legacy':
+      return 'General'
+    default:
+      return ''
+  }
+}
+
+export function ReportsSubNav({ className }: Props) {
+  const pathname = usePathname() ?? ''
+  const { profile } = useAuthZustand()
+  const entries = profile ? filterReportsForProfile(profile) : []
+
+  if (entries.length === 0) return null
+
+  const groups: ReportCatalogEntry['group'][] = ['gerencial', 'operativo', 'legacy']
+
+  return (
+    <nav
+      aria-label="Navegación de reportes"
+      className={cn(
+        'executive-report-no-print border-b border-border/60 bg-muted/30',
+        className
+      )}
+    >
+      <div className="flex flex-col gap-3 px-4 py-3 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between gap-2">
+          <Link
+            href="/reportes"
+            className="text-sm font-semibold text-foreground hover:underline"
+          >
+            Centro de reportes
+          </Link>
+        </div>
+        <div className="flex gap-4 overflow-x-auto scrollbar-none pb-0.5">
+          {groups.map((group) => {
+            const items = entries.filter((e) => e.group === group)
+            if (items.length === 0) return null
+            return (
+              <div key={group} className="flex shrink-0 flex-col gap-1.5">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground px-0.5">
+                  {groupLabel(group)}
+                </span>
+                <div className="flex flex-wrap gap-1.5 sm:flex-nowrap">
+                  {items.map((entry) => {
+                    const active = reportEntryMatchesPath(entry, pathname)
+                    return (
+                      <Link
+                        key={entry.id}
+                        href={entry.href}
+                        className={cn(
+                          'inline-flex shrink-0 items-center rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+                          active
+                            ? 'bg-primary text-primary-foreground shadow-sm'
+                            : 'bg-background border border-border/60 text-muted-foreground hover:text-foreground hover:border-border'
+                        )}
+                      >
+                        {entry.label}
+                      </Link>
+                    )
+                  })}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -39,7 +39,9 @@ import {
   Droplet,
   IdCard,
   Target,
+  TrendingUp,
 } from "lucide-react"
+import { reportsNavItemsForProfile } from '@/lib/reports/reports-catalog'
 import { UserNav } from "@/components/user-nav"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
@@ -795,7 +797,7 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
 
 
 
-        {/* Records Section */}
+        {/* Reportes */}
         {ui.shouldShowInNavigation('reports') && (
           <div className="px-4">
             <Collapsible open={recordsOpen} onOpenChange={setRecordsOpen}>
@@ -806,7 +808,7 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                 >
                   <div className="flex items-center">
                     <FileText className="mr-2 h-4 w-4" />
-                    Históricos
+                    Reportes
                   </div>
                   {recordsOpen ? (
                     <ChevronDown className="h-4 w-4" />
@@ -817,27 +819,49 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
               </CollapsibleTrigger>
               <CollapsibleContent className="space-y-1 mt-2 transition-all duration-200 ease-in-out motion-reduce:transition-none">
                 <Button
-                  variant={isReportesHubPathActive(pathname) ? "secondary" : "ghost"}
-                  className={cn("w-full justify-start pl-8", navItemClasses)}
+                  variant={pathname === '/reportes' ? 'secondary' : 'ghost'}
+                  className={cn('w-full justify-start pl-8', navItemClasses)}
                   asChild
                   onClick={handleLinkClick}
                 >
                   <Link href="/reportes">
                     <BarChart3 className="mr-2 h-4 w-4" />
-                    Reportes
+                    Centro de reportes
                   </Link>
                 </Button>
-                <Button
-                  variant={isPathActive("/reportes/eficiencia-diesel") ? "secondary" : "ghost"}
-                  className={cn("w-full justify-start pl-8", navItemClasses)}
-                  asChild
-                  onClick={handleLinkClick}
-                >
-                  <Link href="/reportes/eficiencia-diesel">
-                    <Fuel className="mr-2 h-4 w-4" />
-                    Eficiencia de Diesel
-                  </Link>
-                </Button>
+                {profile &&
+                  reportsNavItemsForProfile(profile).map((entry) => {
+                    const Icon =
+                      entry.id === 'eficiencia-diesel'
+                        ? Fuel
+                        : entry.id === 'checklists'
+                          ? ClipboardCheck
+                          : entry.id === 'informe-ejecutivo'
+                            ? FileText
+                            : entry.id === 'ingresos-gastos'
+                              ? DollarSign
+                              : entry.id === 'analisis-costos'
+                                ? TrendingUp
+                                : entry.id === 'manual-costs'
+                                  ? Settings
+                                  : BarChart3
+                    const active =
+                      pathname === entry.href || pathname.startsWith(`${entry.href}/`)
+                    return (
+                      <Button
+                        key={entry.id}
+                        variant={active ? 'secondary' : 'ghost'}
+                        className={cn('w-full justify-start pl-8', navItemClasses)}
+                        asChild
+                        onClick={handleLinkClick}
+                      >
+                        <Link href={entry.href}>
+                          <Icon className="mr-2 h-4 w-4" />
+                          {entry.label}
+                        </Link>
+                      </Button>
+                    )
+                  })}
               </CollapsibleContent>
             </Collapsible>
           </div>
@@ -1220,22 +1244,33 @@ function buildNavigationSections(
     })
   }
 
-  // Records (Históricos)
+  // Reportes — gerencial suite + operativo
   if (ui.shouldShowInNavigation('reports')) {
+    const reportNavEntries = reportsNavItemsForProfile(profile)
+    const iconById: Record<string, React.ComponentType<{ className?: string }>> = {
+      gerencial: BarChart3,
+      'informe-ejecutivo': FileText,
+      'ingresos-gastos': DollarSign,
+      'analisis-costos': TrendingUp,
+      'manual-costs': Settings,
+      'eficiencia-diesel': Fuel,
+      checklists: ClipboardCheck,
+    }
+    const reportItems: NavItem[] = [
+      { href: '/reportes', icon: BarChart3, label: 'Centro de reportes', active: pathname === '/reportes' },
+      ...reportNavEntries.map((entry) => ({
+        href: entry.href,
+        icon: iconById[entry.id] ?? BarChart3,
+        label: entry.label,
+        active: pathname === entry.href || pathname.startsWith(`${entry.href}/`),
+      })),
+    ]
     sections.push({
-      id: "records",
+      id: 'records',
       icon: FileText,
-      label: "Históricos",
-      active: isSectionActive(["/reportes"]),
-      items: [
-        { href: "/reportes", icon: BarChart3, label: "Reportes", active: isReportesHubPathActive(pathname) },
-        {
-          href: "/reportes/eficiencia-diesel",
-          icon: Fuel,
-          label: "Eficiencia de Diesel",
-          active: isPathActive("/reportes/eficiencia-diesel"),
-        },
-      ],
+      label: 'Reportes',
+      active: isSectionActive(['/reportes']),
+      items: reportItems,
     })
   }
 

--- a/hooks/useDashboardMaintenanceCost.ts
+++ b/hooks/useDashboardMaintenanceCost.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react"
 import useSWR from "swr"
+import { canAccessIngresosGastosReport } from "@/lib/reports/reports-catalog"
 
 interface MonthCosts {
   maintenanceCost: number
@@ -54,7 +55,16 @@ function aggregateFromResponse(data: unknown): { current: MonthCosts; lastMonth:
   return { current, lastMonth }
 }
 
-async function fetchDashboardMaintenanceCost(month: string): Promise<{
+function monthBounds(month: string): { dateFrom: string; dateTo: string } {
+  const [yr, mNum] = month.split("-").map(Number)
+  const lastDay = new Date(yr, mNum, 0).getDate()
+  return {
+    dateFrom: `${month}-01`,
+    dateTo: `${month}-${String(lastDay).padStart(2, "0")}`,
+  }
+}
+
+async function fetchFromIngresosGastos(month: string): Promise<{
   current: MonthCosts
   lastMonth: MonthCosts | null
 }> {
@@ -78,15 +88,48 @@ async function fetchDashboardMaintenanceCost(month: string): Promise<{
   return aggregateFromResponse(json)
 }
 
-export function useDashboardMaintenanceCost(): DashboardMaintenanceCostResult {
+async function fetchFromGerencial(month: string): Promise<{
+  current: MonthCosts
+  lastMonth: MonthCosts | null
+}> {
+  const { dateFrom, dateTo } = monthBounds(month)
+  const res = await fetch("/api/reports/gerencial", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ dateFrom, dateTo, hideZeroActivity: false }),
+  })
+  if (!res.ok) {
+    throw new Error(`gerencial KPI: HTTP ${res.status}`)
+  }
+  const json = await res.json()
+  const summary = json.summary as {
+    totalMaintenanceCost?: number
+    totalDieselCost?: number
+  }
+  return {
+    current: {
+      maintenanceCost: Number(summary.totalMaintenanceCost ?? 0),
+      dieselCost: Number(summary.totalDieselCost ?? 0),
+    },
+    lastMonth: null,
+  }
+}
+
+export function useDashboardMaintenanceCost(profile?: {
+  role?: string | null
+  business_role?: string | null
+}): DashboardMaintenanceCostResult {
   const month = useMemo(() => {
     const now = new Date()
     return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`
   }, [])
 
+  const useIngresos = profile ? canAccessIngresosGastosReport(profile) : false
+
   const { data, isLoading, mutate } = useSWR(
-    ["dashboard-maintenance-cost", month] as const,
-    ([, m]) => fetchDashboardMaintenanceCost(m),
+    ["dashboard-maintenance-cost", month, useIngresos ? "ingresos" : "gerencial"] as const,
+    ([, m, source]) =>
+      source === "ingresos" ? fetchFromIngresosGastos(m) : fetchFromGerencial(m),
     {
       dedupingInterval: 120_000,
       revalidateOnFocus: true,

--- a/lib/reports/executive-dashboard-shortcuts.ts
+++ b/lib/reports/executive-dashboard-shortcuts.ts
@@ -1,0 +1,42 @@
+import type { LegacyDbRole } from '@/lib/auth/role-model'
+
+export type DashboardReportShortcut = {
+  label: string
+  href: string
+}
+
+/** Quick links for executive roles — surfaced on role dashboards. */
+export function reportShortcutsForRole(role: string | null | undefined): DashboardReportShortcut[] {
+  switch (role as LegacyDbRole | undefined) {
+    case 'GERENCIA_GENERAL':
+      return [
+        { label: 'Centro de reportes', href: '/reportes' },
+        { label: 'Reporte gerencial', href: '/reportes/gerencial' },
+        { label: 'Informe ejecutivo', href: '/reportes/gerencial/informe-ejecutivo' },
+        { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
+        { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
+      ]
+    case 'GERENTE_MANTENIMIENTO':
+      return [
+        { label: 'Informe ejecutivo', href: '/reportes/gerencial/informe-ejecutivo' },
+        { label: 'Reporte gerencial', href: '/reportes/gerencial' },
+        { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
+        { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
+      ]
+    case 'JEFE_UNIDAD_NEGOCIO':
+      return [
+        { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
+        { label: 'Reporte gerencial', href: '/reportes/gerencial' },
+        { label: 'Informe ejecutivo', href: '/reportes/gerencial/informe-ejecutivo' },
+        { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
+      ]
+    case 'AREA_ADMINISTRATIVA':
+      return [
+        { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
+        { label: 'Centro de mando', href: '/reportes/gerencial/analisis-costos' },
+        { label: 'Reporte gerencial', href: '/reportes/gerencial' },
+      ]
+    default:
+      return [{ label: 'Centro de reportes', href: '/reportes' }]
+  }
+}

--- a/lib/reports/executive-dashboard-shortcuts.ts
+++ b/lib/reports/executive-dashboard-shortcuts.ts
@@ -1,42 +1,48 @@
 import type { LegacyDbRole } from '@/lib/auth/role-model'
+import { canAccessIngresosGastosReport } from '@/lib/reports/reports-catalog'
 
 export type DashboardReportShortcut = {
   label: string
   href: string
 }
 
+type ProfileLike = { role?: string | null; business_role?: string | null }
+
+const BASE_BY_ROLE: Partial<Record<LegacyDbRole, DashboardReportShortcut[]>> = {
+  GERENCIA_GENERAL: [
+    { label: 'Centro de reportes', href: '/reportes' },
+    { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
+    { label: 'Reporte gerencial', href: '/reportes/gerencial' },
+    { label: 'Informe ejecutivo', href: '/reportes/gerencial/informe-ejecutivo' },
+    { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
+  ],
+  JEFE_UNIDAD_NEGOCIO: [
+    { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
+    { label: 'Reporte gerencial', href: '/reportes/gerencial' },
+    { label: 'Informe ejecutivo', href: '/reportes/gerencial/informe-ejecutivo' },
+    { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
+  ],
+  GERENTE_MANTENIMIENTO: [
+    { label: 'Informe ejecutivo', href: '/reportes/gerencial/informe-ejecutivo' },
+    { label: 'Reporte gerencial', href: '/reportes/gerencial' },
+    { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
+  ],
+  AREA_ADMINISTRATIVA: [
+    { label: 'Centro de mando', href: '/reportes/gerencial/analisis-costos' },
+    { label: 'Reporte gerencial', href: '/reportes/gerencial' },
+    { label: 'Centro de reportes', href: '/reportes' },
+  ],
+}
+
 /** Quick links for executive roles — surfaced on role dashboards. */
-export function reportShortcutsForRole(role: string | null | undefined): DashboardReportShortcut[] {
-  switch (role as LegacyDbRole | undefined) {
-    case 'GERENCIA_GENERAL':
-      return [
-        { label: 'Centro de reportes', href: '/reportes' },
-        { label: 'Reporte gerencial', href: '/reportes/gerencial' },
-        { label: 'Informe ejecutivo', href: '/reportes/gerencial/informe-ejecutivo' },
-        { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
-        { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
-      ]
-    case 'GERENTE_MANTENIMIENTO':
-      return [
-        { label: 'Informe ejecutivo', href: '/reportes/gerencial/informe-ejecutivo' },
-        { label: 'Reporte gerencial', href: '/reportes/gerencial' },
-        { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
-        { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
-      ]
-    case 'JEFE_UNIDAD_NEGOCIO':
-      return [
-        { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
-        { label: 'Reporte gerencial', href: '/reportes/gerencial' },
-        { label: 'Informe ejecutivo', href: '/reportes/gerencial/informe-ejecutivo' },
-        { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
-      ]
-    case 'AREA_ADMINISTRATIVA':
-      return [
-        { label: 'Ingresos vs gastos', href: '/reportes/gerencial/ingresos-gastos' },
-        { label: 'Centro de mando', href: '/reportes/gerencial/analisis-costos' },
-        { label: 'Reporte gerencial', href: '/reportes/gerencial' },
-      ]
-    default:
-      return [{ label: 'Centro de reportes', href: '/reportes' }]
-  }
+export function reportShortcutsForRole(
+  role: string | null | undefined,
+  profile?: ProfileLike
+): DashboardReportShortcut[] {
+  const p = profile ?? { role }
+  const list = BASE_BY_ROLE[role as LegacyDbRole] ?? [{ label: 'Centro de reportes', href: '/reportes' }]
+  return list.filter((s) => {
+    if (s.href.includes('/ingresos-gastos')) return canAccessIngresosGastosReport(p)
+    return true
+  })
 }

--- a/lib/reports/executive-report-rollup.test.ts
+++ b/lib/reports/executive-report-rollup.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildExecutiveReportRollup,
+  mapAssetToExecutiveCategory,
+  type GerencialAssetForRollup,
+} from './executive-report-rollup.ts'
+
+test('mapAssetToExecutiveCategory maps mixer codes', () => {
+  assert.equal(
+    mapAssetToExecutiveCategory({ asset_code: 'CR-15', asset_name: 'Mixer', id: '1' } as GerencialAssetForRollup),
+    'Ollas Revolvedoras'
+  )
+})
+
+test('buildExecutiveReportRollup tracks unallocated maintenance', () => {
+  const assets: GerencialAssetForRollup[] = [
+    {
+      id: 'a1',
+      asset_code: 'CR-01',
+      asset_name: 'Mixer 1',
+      maintenance_cost: 100,
+      preventive_cost: 40,
+      corrective_cost: 60,
+      hours_worked: 10,
+      concrete_m3: 50,
+    },
+  ]
+  const rollup = buildExecutiveReportRollup(
+    assets,
+    {
+      totalSales: 0,
+      totalMaintenanceCost: 150,
+      totalPreventiveCost: 40,
+      totalCorrectiveCost: 60,
+      totalConcreteM3: 50,
+    },
+    { dateFrom: '2026-01-01', dateTo: '2026-01-31' }
+  )
+  assert.equal(rollup.maintenance_attributed_to_assets, 100)
+  assert.equal(rollup.unallocated_maintenance, 50)
+  assert.equal(rollup.summary.cost_per_m3, 3)
+})

--- a/lib/reports/report-api-auth.ts
+++ b/lib/reports/report-api-auth.ts
@@ -3,7 +3,11 @@ import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { effectiveRoleForPermissions } from '@/lib/auth/role-model'
 import { loadActorContext, type ActorContext } from '@/lib/auth/server-authorization'
 import { hasModuleAccess } from '@/lib/auth/role-permissions'
-import { canAccessManualCostsReport, canAccessReportsModule } from '@/lib/reports/reports-catalog'
+import {
+  canAccessIngresosGastosReport,
+  canAccessManualCostsReport,
+  canAccessReportsModule,
+} from '@/lib/reports/reports-catalog'
 
 export type ReportsApiAuthResult =
   | { ok: true; actor: ActorContext; supabase: Awaited<ReturnType<typeof createServerSupabase>> }
@@ -42,6 +46,24 @@ export async function requireReportsApiAccess(): Promise<ReportsApiAuthResult> {
   }
 
   return { ok: true, actor, supabase }
+}
+
+export async function requireIngresosGastosApiAccess(): Promise<ReportsApiAuthResult> {
+  const base = await requireReportsApiAccess()
+  if (!base.ok) return base
+  if (!canAccessIngresosGastosReport(base.actor.profile)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error:
+            'Ingresos vs gastos solo está disponible para Gerencia General y Jefe de Unidad de Negocio',
+        },
+        { status: 403 }
+      ),
+    }
+  }
+  return base
 }
 
 export async function requireManualCostsApiAccess(): Promise<ReportsApiAuthResult> {

--- a/lib/reports/report-api-auth.ts
+++ b/lib/reports/report-api-auth.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server'
+import { createClient as createServerSupabase } from '@/lib/supabase-server'
+import { effectiveRoleForPermissions } from '@/lib/auth/role-model'
+import { loadActorContext, type ActorContext } from '@/lib/auth/server-authorization'
+import { hasModuleAccess } from '@/lib/auth/role-permissions'
+import { canAccessManualCostsReport, canAccessReportsModule } from '@/lib/reports/reports-catalog'
+
+export type ReportsApiAuthResult =
+  | { ok: true; actor: ActorContext; supabase: Awaited<ReturnType<typeof createServerSupabase>> }
+  | { ok: false; response: NextResponse }
+
+export async function requireReportsApiAccess(): Promise<ReportsApiAuthResult> {
+  const supabase = await createServerSupabase()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'No autenticado' }, { status: 401 }),
+    }
+  }
+
+  const actor = await loadActorContext(supabase, user.id)
+  if (!actor) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Perfil no encontrado' }, { status: 403 }),
+    }
+  }
+
+  if (!canAccessReportsModule(actor.profile)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Sin permiso para módulo de reportes' },
+        { status: 403 }
+      ),
+    }
+  }
+
+  return { ok: true, actor, supabase }
+}
+
+export async function requireManualCostsApiAccess(): Promise<ReportsApiAuthResult> {
+  const base = await requireReportsApiAccess()
+  if (!base.ok) return base
+  if (!canAccessManualCostsReport(base.actor.profile)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Sin permiso para costos manuales' },
+        { status: 403 }
+      ),
+    }
+  }
+  return base
+}
+
+/** Recompute eficiencia diésel — maintenance leadership + gerencia. */
+export function canRecomputeDieselEfficiency(actor: ActorContext): boolean {
+  const key = effectiveRoleForPermissions(actor.profile)
+  if (!key) return false
+  if (!hasModuleAccess(key, 'reports')) return false
+  const role = actor.profile.role
+  return (
+    role === 'GERENCIA_GENERAL' ||
+    role === 'GERENTE_MANTENIMIENTO' ||
+    role === 'AREA_ADMINISTRATIVA' ||
+    role === 'JEFE_UNIDAD_NEGOCIO'
+  )
+}

--- a/lib/reports/reports-catalog.ts
+++ b/lib/reports/reports-catalog.ts
@@ -87,6 +87,25 @@ const MANUAL_COSTS_ROLES = new Set<LegacyDbRole | FutureBusinessRole>([
   'JEFE_UNIDAD_NEGOCIO',
 ])
 
+/** Ingresos vs gastos P&L — solo dirección general y jefes de unidad de negocio. */
+const INGRESOS_GASTOS_ROLES = new Set<LegacyDbRole | FutureBusinessRole>([
+  'GERENCIA_GENERAL',
+  'JEFE_UNIDAD_NEGOCIO',
+])
+
+export const INGRESOS_GASTOS_PATH_PREFIX = '/reportes/gerencial/ingresos-gastos'
+
+function roleInSet(
+  profile: { role?: string | null; business_role?: string | null },
+  allowed: Set<LegacyDbRole | FutureBusinessRole>
+): boolean {
+  const role = profile.role as LegacyDbRole | undefined
+  const br = profile.business_role as FutureBusinessRole | undefined
+  return (
+    (role != null && allowed.has(role)) || (br != null && allowed.has(br))
+  )
+}
+
 function permissionRoleKey(profile: {
   role?: string | null
   business_role?: string | null
@@ -103,6 +122,14 @@ export function canAccessReportsModule(profile: {
   return key ? hasModuleAccess(key, 'reports') : false
 }
 
+export function canAccessIngresosGastosReport(profile: {
+  role?: string | null
+  business_role?: string | null
+}): boolean {
+  if (!canAccessReportsModule(profile)) return false
+  return roleInSet(profile, INGRESOS_GASTOS_ROLES)
+}
+
 export function canAccessManualCostsReport(profile: {
   role?: string | null
   business_role?: string | null
@@ -111,12 +138,7 @@ export function canAccessManualCostsReport(profile: {
   const key = permissionRoleKey(profile)
   if (!key) return false
   if (hasWriteAccess(key, 'config')) return true
-  const role = profile.role as LegacyDbRole | undefined
-  const br = profile.business_role as FutureBusinessRole | undefined
-  return (
-    (role != null && MANUAL_COSTS_ROLES.has(role)) ||
-    (br != null && MANUAL_COSTS_ROLES.has(br))
-  )
+  return roleInSet(profile, MANUAL_COSTS_ROLES)
 }
 
 export function filterReportsForProfile(profile: {
@@ -126,6 +148,7 @@ export function filterReportsForProfile(profile: {
   if (!canAccessReportsModule(profile)) return []
 
   return REPORT_CATALOG.filter((entry) => {
+    if (entry.id === 'ingresos-gastos') return canAccessIngresosGastosReport(profile)
     if (entry.id === 'manual-costs') return canAccessManualCostsReport(profile)
     if (entry.id === 'legacy-analytics') {
       const key = permissionRoleKey(profile)
@@ -149,6 +172,25 @@ export function reportEntryMatchesPath(entry: ReportCatalogEntry, pathname: stri
     return pathname === '/reportes'
   }
   return pathname === prefix || pathname.startsWith(`${prefix}/`)
+}
+
+/** Report-specific gates on top of module `reports` access (used by RoleProvider). */
+export function canAccessReportPath(
+  profile: { role?: string | null; business_role?: string | null },
+  pathname: string
+): boolean {
+  if (!pathname.startsWith('/reportes')) return true
+  if (!canAccessReportsModule(profile)) return false
+  if (
+    pathname === INGRESOS_GASTOS_PATH_PREFIX ||
+    pathname.startsWith(`${INGRESOS_GASTOS_PATH_PREFIX}/`)
+  ) {
+    return canAccessIngresosGastosReport(profile)
+  }
+  if (pathname.startsWith('/reportes/gerencial/manual-costs')) {
+    return canAccessManualCostsReport(profile)
+  }
+  return true
 }
 
 export function activeReportFromPath(

--- a/lib/reports/reports-catalog.ts
+++ b/lib/reports/reports-catalog.ts
@@ -1,0 +1,220 @@
+import {
+  effectiveRoleForPermissions,
+  type FutureBusinessRole,
+  type LegacyDbRole,
+} from '@/lib/auth/role-model'
+import {
+  hasModuleAccess,
+  hasWriteAccess,
+  type ModulePermissions,
+} from '@/lib/auth/role-permissions'
+
+export type ReportCatalogEntry = {
+  id: string
+  href: string
+  label: string
+  description: string
+  group: 'gerencial' | 'operativo' | 'legacy'
+  /** Path prefix for active state (defaults to href) */
+  matchPrefix?: string
+}
+
+export const REPORT_CATALOG: ReportCatalogEntry[] = [
+  {
+    id: 'gerencial',
+    href: '/reportes/gerencial',
+    label: 'Reporte gerencial',
+    description: 'Ventas, diésel FIFO, mantenimiento y producción por activo, planta y unidad.',
+    group: 'gerencial',
+  },
+  {
+    id: 'informe-ejecutivo',
+    href: '/reportes/gerencial/informe-ejecutivo',
+    label: 'Informe ejecutivo',
+    description: 'Análisis de mantenimiento para dirección (gráficos, ratios, top equipos).',
+    group: 'gerencial',
+  },
+  {
+    id: 'ingresos-gastos',
+    href: '/reportes/gerencial/ingresos-gastos',
+    label: 'Ingresos vs gastos',
+    description: 'P&L por planta: ventas, diésel, MANTTO, nómina, EBITDA.',
+    group: 'gerencial',
+  },
+  {
+    id: 'analisis-costos',
+    href: '/reportes/gerencial/analisis-costos',
+    label: 'Centro de mando',
+    description: 'Estructura de costos, correctivo vs preventivo, drill-down financiero.',
+    group: 'gerencial',
+  },
+  {
+    id: 'manual-costs',
+    href: '/reportes/gerencial/manual-costs',
+    label: 'Costos manuales',
+    description: 'Ajustes y cargas indirectas que alimentan ingresos-gastos.',
+    group: 'gerencial',
+  },
+  {
+    id: 'eficiencia-diesel',
+    href: '/reportes/eficiencia-diesel',
+    label: 'Eficiencia diésel',
+    description: 'L/h y L/km confiables por activo — fuente de verdad para métricas operativas.',
+    group: 'operativo',
+    matchPrefix: '/reportes/eficiencia-diesel',
+  },
+  {
+    id: 'checklists',
+    href: '/reportes/checklists',
+    label: 'Checklists',
+    description: 'Cumplimiento de inspecciones y problemas recurrentes.',
+    group: 'operativo',
+  },
+  {
+    id: 'legacy-analytics',
+    href: '/reportes',
+    label: 'Dashboard analítico',
+    description: 'Vista histórica de indicadores (reporte ejecutivo legacy).',
+    group: 'legacy',
+    matchPrefix: '/reportes',
+  },
+]
+
+const MANUAL_COSTS_ROLES = new Set<LegacyDbRole | FutureBusinessRole>([
+  'GERENCIA_GENERAL',
+  'AREA_ADMINISTRATIVA',
+  'GERENTE_MANTENIMIENTO',
+  'JEFE_UNIDAD_NEGOCIO',
+])
+
+function permissionRoleKey(profile: {
+  role?: string | null
+  business_role?: string | null
+}): string | null {
+  return effectiveRoleForPermissions(profile)
+}
+
+/** Whether the user may open any report route. */
+export function canAccessReportsModule(profile: {
+  role?: string | null
+  business_role?: string | null
+}): boolean {
+  const key = permissionRoleKey(profile)
+  return key ? hasModuleAccess(key, 'reports') : false
+}
+
+export function canAccessManualCostsReport(profile: {
+  role?: string | null
+  business_role?: string | null
+}): boolean {
+  if (!canAccessReportsModule(profile)) return false
+  const key = permissionRoleKey(profile)
+  if (!key) return false
+  if (hasWriteAccess(key, 'config')) return true
+  const role = profile.role as LegacyDbRole | undefined
+  const br = profile.business_role as FutureBusinessRole | undefined
+  return (
+    (role != null && MANUAL_COSTS_ROLES.has(role)) ||
+    (br != null && MANUAL_COSTS_ROLES.has(br))
+  )
+}
+
+export function filterReportsForProfile(profile: {
+  role?: string | null
+  business_role?: string | null
+}): ReportCatalogEntry[] {
+  if (!canAccessReportsModule(profile)) return []
+
+  return REPORT_CATALOG.filter((entry) => {
+    if (entry.id === 'manual-costs') return canAccessManualCostsReport(profile)
+    if (entry.id === 'legacy-analytics') {
+      const key = permissionRoleKey(profile)
+      return key ? hasModuleAccess(key, 'reports') : false
+    }
+    return true
+  })
+}
+
+/** Nav items for sidebar (excludes legacy hub duplicate when gerencial exists). */
+export function reportsNavItemsForProfile(profile: {
+  role?: string | null
+  business_role?: string | null
+}): ReportCatalogEntry[] {
+  return filterReportsForProfile(profile).filter((e) => e.id !== 'legacy-analytics')
+}
+
+export function reportEntryMatchesPath(entry: ReportCatalogEntry, pathname: string): boolean {
+  const prefix = entry.matchPrefix ?? entry.href
+  if (entry.id === 'legacy-analytics') {
+    return pathname === '/reportes'
+  }
+  return pathname === prefix || pathname.startsWith(`${prefix}/`)
+}
+
+export function activeReportFromPath(
+  pathname: string,
+  profile: { role?: string | null; business_role?: string | null }
+): ReportCatalogEntry | null {
+  const entries = filterReportsForProfile(profile)
+  const sorted = [...entries].sort(
+    (a, b) => (b.matchPrefix ?? b.href).length - (a.matchPrefix ?? a.href).length
+  )
+  for (const entry of sorted) {
+    if (reportEntryMatchesPath(entry, pathname)) return entry
+  }
+  return null
+}
+
+export type GerencialMetricSpec = {
+  id: string
+  label: string
+  source: string
+  alignedWith?: string
+}
+
+/** Documented metric lineage for gerencial / informe / eficiencia diésel. */
+export const GERENCIAL_METRICS_SPEC: GerencialMetricSpec[] = [
+  {
+    id: 'diesel_cost',
+    label: 'Costo diésel',
+    source: 'FIFO por transacción de consumo (lib/fifo-diesel-costs)',
+    alignedWith: 'ingresos-gastos diesel_total',
+  },
+  {
+    id: 'diesel_liters',
+    label: 'Litros diésel',
+    source: 'Suma quantity_liters en consumos (excl. transferencias)',
+    alignedWith: 'eficiencia-diesel total_liters',
+  },
+  {
+    id: 'liters_per_hour',
+    label: 'L/h',
+    source: 'litros / horas confiables (merged-first, diesel-efficiency-hours-policy)',
+    alignedWith: 'asset_diesel_efficiency_monthly.liters_per_hour_trusted',
+  },
+  {
+    id: 'liters_per_km',
+    label: 'L/km',
+    source: 'litros / km confiables (computeMergedOperatingKmByAsset)',
+    alignedWith: 'asset_diesel_efficiency_monthly.liters_per_km',
+  },
+  {
+    id: 'maintenance_cost',
+    label: 'Mantenimiento',
+    source: 'POs con OT, excl. restock; preventivo/correctivo por tipo OT',
+    alignedWith: 'ingresos-gastos mantto_total',
+  },
+  {
+    id: 'concrete_m3',
+    label: 'Producción m³',
+    source: 'Cotizador remisiones / vista financiera unificada',
+    alignedWith: 'ingresos-gastos volumen_concreto',
+  },
+  {
+    id: 'cost_per_m3',
+    label: 'Costo mantenimiento / m³',
+    source: 'totalMaintenanceCost / totalConcreteM3 (informe rollup)',
+  },
+]
+
+export type ReportsModuleKey = keyof ModulePermissions

--- a/lib/reports/run-gerencial-report.ts
+++ b/lib/reports/run-gerencial-report.ts
@@ -10,6 +10,7 @@ import {
   computeMergedOperatingHoursByAsset,
   fetchDieselPeriodConsumptionTxsForReportAssets,
 } from '@/lib/reports/merged-operating-hours'
+import { computeMergedOperatingKmByAsset } from '@/lib/reports/merged-operating-km'
 
 export type GerencialReportBody = {
   dateFrom: string
@@ -538,6 +539,9 @@ export async function runGerencialReport(
         hours_merge_fork: false,
         liters_per_hour: 0,
         kilometers_worked: 0,
+        kilometers_worked_diesel_consumed: 0,
+        kilometers_worked_merged: 0,
+        km_merge_fork: false,
         liters_per_km: 0,
         maintenance_cost: 0,
         preventive_cost: 0,
@@ -584,18 +588,18 @@ export async function runGerencialReport(
       asset.diesel_cost += cost
     })
 
-    // Efficiency: use diesel-only SUM of generated columns (matches breakdown modal)
+    // Row-level sums for trusted hours/km (same policy as eficiencia diésel)
     const dieselConsumedHoursByAsset = new Map<string, number>()
+    const dieselConsumedKmByAsset = new Map<string, number>()
     dieselByAsset.forEach((txs, assetId) => {
       const asset = assetMap.get(assetId)
       if (!asset) return
       const hours_consumed_sum = txs.reduce((sum: number, t: any) => sum + Number(t.hours_consumed || 0), 0)
-      const kilometers_worked = txs.reduce((sum: number, t: any) => sum + Number(t.kilometers_consumed || 0), 0)
+      const km_consumed_sum = txs.reduce((sum: number, t: any) => sum + Number(t.kilometers_consumed || 0), 0)
       asset.hours_worked_diesel_consumed = hours_consumed_sum
+      asset.kilometers_worked_diesel_consumed = km_consumed_sum
       dieselConsumedHoursByAsset.set(assetId, hours_consumed_sum)
-      asset.kilometers_worked = kilometers_worked
-      asset.liters_per_km =
-        kilometers_worked > 0 && asset.diesel_liters > 0 ? asset.diesel_liters / kilometers_worked : 0
+      dieselConsumedKmByAsset.set(assetId, km_consumed_sum)
     })
 
     const realAssetIds = [...assetMap.keys()].filter((id) => !String(id).startsWith('unmatched_'))
@@ -618,6 +622,24 @@ export async function runGerencialReport(
       }>,
     })
 
+    const {
+      kmByAsset: mergedKmByAsset,
+      kmMergedByAsset,
+      mergeForkKmByAsset,
+      diagnostics: kmMergeDiagnostics,
+    } = await computeMergedOperatingKmByAsset(supabase as unknown as SupabaseClient, {
+      assetIds: realAssetIds,
+      dateFromStart,
+      dateToExclusive,
+      dateToExclusiveStr,
+      dieselConsumedKmByAsset,
+      periodDieselConsumptionTxs: dieselTxs as Array<{
+        asset_id: string | null
+        kilometers_consumed?: number | null
+        transaction_type?: string | null
+      }>,
+    })
+
     mergedHoursByAsset.forEach((hours, assetId) => {
       const asset = assetMap.get(assetId)
       if (!asset) return
@@ -633,6 +655,23 @@ export async function runGerencialReport(
       asset.hours_worked_merged = hoursMergedByAsset.get(id) ?? 0
       asset.hours_merge_fork = mergeForkByAsset.get(id) ?? false
       asset.liters_per_hour = 0
+    })
+
+    mergedKmByAsset.forEach((km, assetId) => {
+      const asset = assetMap.get(assetId)
+      if (!asset) return
+      asset.kilometers_worked = km
+      asset.kilometers_worked_merged = kmMergedByAsset.get(assetId) ?? 0
+      asset.km_merge_fork = mergeForkKmByAsset.get(assetId) ?? false
+      asset.liters_per_km = km > 0 && asset.diesel_liters > 0 ? asset.diesel_liters / km : 0
+    })
+    assetMap.forEach((asset, id) => {
+      if (String(id).startsWith('unmatched_')) return
+      if (mergedKmByAsset.has(id)) return
+      asset.kilometers_worked = 0
+      asset.kilometers_worked_merged = kmMergedByAsset.get(id) ?? 0
+      asset.km_merge_fork = mergeForkKmByAsset.get(assetId) ?? false
+      asset.liters_per_km = 0
     })
 
     // Separate POs by purpose to track cash vs inventory expenses
@@ -1171,7 +1210,13 @@ export async function runGerencialReport(
     // Build assets array for response; optionally hide zero-activity assets
     const assetsArrayAll = Array.from(assetMap.values())
     const assetsArray = hideZeroActivity
-      ? assetsArrayAll.filter((a: any) => (a.hours_worked || 0) > 0 || (a.diesel_liters || 0) > 0)
+      ? assetsArrayAll.filter(
+          (a: any) =>
+            (a.hours_worked || 0) > 0 ||
+            (a.kilometers_worked || 0) > 0 ||
+            (a.diesel_liters || 0) > 0 ||
+            (a.maintenance_cost || 0) > 0
+        )
       : assetsArrayAll
 
     // Calculate cash flow summary
@@ -1204,7 +1249,10 @@ export async function runGerencialReport(
         hours_attribution: {
           ...hoursMergeDiagnostics,
           method:
-            'Por activo: max(horas por avance de horómetro diésel + lecturas de checklist en el periodo, suma de hours_consumed en consumos).',
+            'Horas y km confiables: curva fusionada horómetro diésel + checklist (con topes); si no hay curva, suma de hours_consumed / kilometers_consumed. Misma política que Eficiencia diésel.',
+        },
+        km_attribution: {
+          ...kmMergeDiagnostics,
         },
       },
       businessUnits: Array.from(buMap.values()),

--- a/scripts/verify-gerencial-diesel-parity.ts
+++ b/scripts/verify-gerencial-diesel-parity.ts
@@ -1,0 +1,90 @@
+/**
+ * Compare L/h per asset: runGerencialReport vs asset_diesel_efficiency_monthly for one calendar month.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/verify-gerencial-diesel-parity.ts 2026-05
+ *
+ * Requires Supabase env vars. Flags pairs where |Δ| > 0.05 L/h (rounding / scope).
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/supabase-types'
+import { runGerencialReport } from '@/lib/reports/run-gerencial-report'
+
+const EPS_LPH = 0.05
+
+async function main() {
+  const month = process.argv[2] || new Date().toISOString().slice(0, 7)
+  const [yr, m] = month.split('-').map(Number)
+  const dateFrom = `${month}-01`
+  const lastDay = new Date(yr, m, 0).getDate()
+  const dateTo = `${month}-${String(lastDay).padStart(2, '0')}`
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY')
+    process.exit(1)
+  }
+
+  const admin = createClient<Database>(url, key, { auth: { persistSession: false } })
+
+  const gerencial = await runGerencialReport(
+    { dateFrom, dateTo, hideZeroActivity: false },
+    { supabase: admin }
+  )
+
+  const { data: effRows, error } = await admin
+    .from('asset_diesel_efficiency_monthly')
+    .select('asset_id, liters_per_hour_trusted, total_liters, hours_trusted')
+    .eq('year_month', month)
+
+  if (error) {
+    console.error('Efficiency table error:', error.message)
+    process.exit(1)
+  }
+
+  const effByAsset = new Map(
+    (effRows || []).map((r) => [r.asset_id, r])
+  )
+
+  let compared = 0
+  let mismatches = 0
+  let missingEff = 0
+
+  for (const asset of (gerencial.assets || []) as Array<{
+    id: string
+    asset_code?: string
+    diesel_liters?: number
+    liters_per_hour?: number
+  }>) {
+    const liters = Number(asset.diesel_liters || 0)
+    const lphG = Number(asset.liters_per_hour || 0)
+    if (liters <= 0 || lphG <= 0) continue
+
+    const eff = effByAsset.get(asset.id)
+    if (!eff?.liters_per_hour_trusted) {
+      missingEff++
+      continue
+    }
+    const lphE = Number(eff.liters_per_hour_trusted)
+    compared++
+    const delta = Math.abs(lphG - lphE)
+    if (delta > EPS_LPH) {
+      mismatches++
+      console.warn('L/h mismatch', asset.asset_code || asset.id, {
+        gerencial: lphG,
+        efficiency: lphE,
+        delta,
+      })
+    }
+  }
+
+  console.log(`Month ${month}: compared ${compared} assets, mismatches ${mismatches}, missing efficiency row ${missingEff}`)
+  process.exit(mismatches > 0 ? 1 : 0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the gerencial maintenance report with **Eficiencia diésel** policy (trusted L/h and L/km), adds a **Centro de reportes** with sidebar navigation and API auth, and restricts **Ingresos vs gastos** to **Gerencia General** and **Jefe de Unidad de Negocio** only.

## Ingresos vs gastos — access (GG + JUN only)

- Catalog, sidebar, and subnav hide the report for all other roles
- `RoleProvider` blocks `/reportes/gerencial/ingresos-gastos` routes
- Page layout guard with clear denial message
- All P&L APIs (`ingresos-gastos`, `details`, `refresh-view`, `refresh-materialized-views`) return 403 for non-GG/JUN
- Dashboard shortcuts and gerencial hub button respect the same rule
- Executive KPI cards use **gerencial API** when the user cannot access ingresos-gastos

**Still allowed without Ingresos vs gastos:** Reporte gerencial, Informe ejecutivo, Eficiencia diésel, Centro de mando (analisis-costos), manual costs (per existing roles).

**Centro de mando fixes:** BU/plant filters via `/api/reports/gerencial/scope-filters` (no P&L leak); operational drill-down uses reports-module auth; back link goes to ingresos-gastos only for GG/JUN.

## Diesel / informe ejecutivo

- Trusted merged km for L/km; hide-zero keeps assets with maintenance cost
- Informe copy and trust banners aligned with eficiencia diésel policy
- `scripts/verify-gerencial-diesel-parity.ts` for month parity checks

## Navigation

- Reports hub, gerencial subnav, expanded sidebar **Reportes** section
- `requireReportsApiAccess` on gerencial and diesel efficiency APIs
- Role dashboards link to the right reports per role
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7f36e63-a421-479e-8da0-cd1c890efa72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7f36e63-a421-479e-8da0-cd1c890efa72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

