### PR TITLE
Fix purchase order quote editing UX and PO sync

### DIFF
--- a/app/api/purchase-orders/quotations/[id]/route.ts
+++ b/app/api/purchase-orders/quotations/[id]/route.ts
@@ -141,8 +141,6 @@ export async function PATCH(
       return NextResponse.json({ error: 'Cotización no encontrada' }, { status: 404 })
     }
 
-    const wasRejected = quotation.status === QuotationStatus.REJECTED
-
     const { data: po, error: poError } = await supabase
       .from('purchase_orders')
       .select('id, plant_id, viability_state, status')
@@ -197,12 +195,18 @@ export async function PATCH(
       )
     }
 
+    const quotationPatch: Record<string, unknown> = {
+      ...updateData,
+      updated_at: new Date().toISOString(),
+    }
+    if (wasRejected) {
+      quotationPatch.status = QuotationStatus.PENDING
+      quotationPatch.rejection_reason = null
+    }
+
     const { data: updated, error: updError } = await supabase
       .from('purchase_order_quotations')
-      .update({
-        ...updateData,
-        updated_at: new Date().toISOString(),
-      })
+      .update(quotationPatch)
       .eq('id', quotation_id)
       .select()
       .single()
@@ -213,6 +217,41 @@ export async function PATCH(
         { error: updError.message || 'Failed to update quotation' },
         { status: 500 }
       )
+    }
+
+    if (!updated) {
+      return NextResponse.json(
+        { error: 'No se pudo leer la cotización actualizada' },
+        { status: 500 }
+      )
+    }
+
+    const isWinningQuotation =
+      updated.status === QuotationStatus.SELECTED ||
+      po.selected_quotation_id === quotation_id
+
+    if (isWinningQuotation) {
+      try {
+        await syncPurchaseOrderFromSelectedQuotation(supabase, {
+          id: updated.id,
+          purchase_order_id: updated.purchase_order_id,
+          quoted_amount: updated.quoted_amount,
+          supplier_name: updated.supplier_name,
+          supplier_id: updated.supplier_id ?? null,
+          quotation_items: updated.quotation_items,
+        })
+      } catch (syncError) {
+        console.error('Error syncing PO from selected quotation:', syncError)
+        return NextResponse.json(
+          {
+            error:
+              syncError instanceof Error
+                ? syncError.message
+                : 'Cotización actualizada pero no se pudo sincronizar la orden de compra',
+          },
+          { status: 500 }
+        )
+      }
     }
 
     return NextResponse.json({ success: true, data: updated })

--- a/app/api/purchase-orders/quotations/[id]/route.ts
+++ b/app/api/purchase-orders/quotations/[id]/route.ts
@@ -141,6 +141,8 @@ export async function PATCH(
       return NextResponse.json({ error: 'Cotización no encontrada' }, { status: 404 })
     }
 
+    const wasRejected = quotation.status === QuotationStatus.REJECTED
+
     const { data: po, error: poError } = await supabase
       .from('purchase_orders')
       .select('id, plant_id, viability_state, status')

--- a/app/compras/[id]/mobile/page.tsx
+++ b/app/compras/[id]/mobile/page.tsx
@@ -172,6 +172,14 @@ async function PurchaseOrderDetailsMobileContent({ id }: { id: string }) {
     }
   }
 
+  const { data: auth } = await supabase.auth.getUser()
+  const actor = auth.user ? await loadActorContext(supabase, auth.user.id) : null
+  const coordinatorQuotationUi = computeCoordinatorQuotationUiState(actor, {
+    plant_id: order.plant_id,
+    viability_state: order.viability_state,
+    status: order.status,
+  })
+
   // Get action buttons based on status
   function getActionButtons(order: any): ReactNode {
     if (!order) return null

--- a/components/purchase-orders/quotations/EnhancedQuotationUploader.tsx
+++ b/components/purchase-orders/quotations/EnhancedQuotationUploader.tsx
@@ -328,7 +328,11 @@ export function EnhancedQuotationUploader({
         }
         const updated = result.data as PurchaseOrderQuotation
         onQuotationUpdated?.(updated)
-        toast.success("Cotización actualizada")
+        toast.success(
+          initialQuotation.status === "selected"
+            ? "Cotización y montos de la orden actualizados"
+            : "Cotización actualizada"
+        )
         return
       }
 

--- a/components/purchase-orders/quotations/QuotationComparisonCard.tsx
+++ b/components/purchase-orders/quotations/QuotationComparisonCard.tsx
@@ -211,14 +211,20 @@ export function QuotationComparisonCard({
           </div>
         )}
 
-        {/* Cotización elegida: solo editar (no eliminar) */}
-        {quotation.status === QuotationStatus.SELECTED && onEdit && (
+        {/* Cotización elegida o rechazada: editar (rechazada vuelve a pendiente al guardar) */}
+        {(quotation.status === QuotationStatus.SELECTED ||
+          quotation.status === QuotationStatus.REJECTED) &&
+          onEdit && (
           <div className="flex flex-wrap gap-2 mt-auto pt-4">
             <Button
               size="sm"
               variant="outline"
               onClick={() => onEdit(quotation.id)}
-              title="Editar cotización seleccionada"
+              title={
+                quotation.status === QuotationStatus.REJECTED
+                  ? "Editar cotización rechazada"
+                  : "Editar cotización seleccionada"
+              }
               className="gap-1"
             >
               <Pencil className="h-4 w-4" />

--- a/components/purchase-orders/quotations/QuotationComparisonManager.tsx
+++ b/components/purchase-orders/quotations/QuotationComparisonManager.tsx
@@ -293,13 +293,6 @@ export function QuotationComparisonManager({
         </p>
       )}
 
-      {quotations.length > 0 && !canMutate && isViewerCoordinator && (
-        <p className="text-xs text-muted-foreground rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900">
-          No puede agregar ni modificar cotizaciones: viabilidad administrativa ya registrada, la orden
-          fuera de su alcance, o estado de la orden no permitido.
-        </p>
-      )}
-
       {/* Add quotation - modal, form only when asked */}
       {showAddQuotation ? (
         <Dialog open={addQuotationOpen} onOpenChange={setAddQuotationOpen}>
@@ -347,9 +340,16 @@ export function QuotationComparisonManager({
               initialQuotation={editingQuotation}
               purchaseOrderId={purchaseOrderId}
               workOrderId={workOrderId}
-              onQuotationUpdated={async () => {
+              onQuotationUpdated={async (updated) => {
                 await loadQuotations()
                 setEditingQuotation(null)
+                if (updated?.status === QuotationStatus.SELECTED) {
+                  window.dispatchEvent(
+                    new CustomEvent('quotationSelected', {
+                      detail: { quotationId: updated.id, purchaseOrderId },
+                    })
+                  )
+                }
                 router.refresh()
               }}
               existingQuotations={quotations}

--- a/components/purchase-orders/quotations/QuotationComparisonManager.tsx
+++ b/components/purchase-orders/quotations/QuotationComparisonManager.tsx
@@ -293,6 +293,13 @@ export function QuotationComparisonManager({
         </p>
       )}
 
+      {quotations.length > 0 && !canMutate && isViewerCoordinator && (
+        <p className="text-xs text-muted-foreground rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900">
+          No puede agregar ni modificar cotizaciones: viabilidad administrativa ya registrada, la orden
+          fuera de su alcance, o estado de la orden no permitido.
+        </p>
+      )}
+
       {/* Add quotation - modal, form only when asked */}
       {showAddQuotation ? (
         <Dialog open={addQuotationOpen} onOpenChange={setAddQuotationOpen}>

--- a/components/purchase-orders/quotations/QuotationComparisonTable.tsx
+++ b/components/purchase-orders/quotations/QuotationComparisonTable.tsx
@@ -219,7 +219,8 @@ export function QuotationComparisonTable({
                     )}
                     {onEdit &&
                       (quotation.status === QuotationStatus.PENDING ||
-                        quotation.status === QuotationStatus.SELECTED) && (
+                        quotation.status === QuotationStatus.SELECTED ||
+                        quotation.status === QuotationStatus.REJECTED) && (
                       <Button
                         size="sm"
                         variant="outline"

--- a/lib/purchase-orders/sync-selected-quotation-to-po.ts
+++ b/lib/purchase-orders/sync-selected-quotation-to-po.ts
@@ -1,0 +1,73 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+type QuotationRow = {
+  id: string
+  purchase_order_id: string
+  quoted_amount: number
+  supplier_name: string
+  supplier_id: string | null
+  quotation_items: unknown
+}
+
+/**
+ * When a selected quotation is updated, mirror key fields onto the purchase order
+ * (same data select_quotation writes on selection).
+ */
+export async function syncPurchaseOrderFromSelectedQuotation(
+  supabase: SupabaseClient,
+  quotation: QuotationRow
+): Promise<void> {
+  const quotationItems = quotation.quotation_items
+  const hasLineItems =
+    quotationItems != null &&
+    Array.isArray(quotationItems) &&
+    quotationItems.length > 0
+
+  const baseUpdate = {
+    total_amount: quotation.quoted_amount,
+    approval_amount: quotation.quoted_amount,
+    approval_amount_source: 'selected_quotation',
+    selected_quotation_id: quotation.id,
+    supplier: quotation.supplier_name,
+    supplier_id: quotation.supplier_id,
+    updated_at: new Date().toISOString(),
+  }
+
+  if (hasLineItems) {
+    const updatedItems = (quotationItems as Record<string, unknown>[]).map((row) => {
+      const item: Record<string, unknown> = {
+        name: row.description,
+        partNumber: row.part_number,
+        quantity: row.quantity,
+        unit_price: row.unit_price,
+        total_price: row.total_price,
+        quoted_unit_price: row.unit_price,
+        brand: row.brand,
+        notes: row.notes,
+      }
+      if (row.part_id != null) {
+        item.part_id = row.part_id
+      }
+      return item
+    })
+
+    const { error } = await supabase
+      .from('purchase_orders')
+      .update({ ...baseUpdate, items: updatedItems })
+      .eq('id', quotation.purchase_order_id)
+
+    if (error) {
+      throw new Error(error.message)
+    }
+    return
+  }
+
+  const { error } = await supabase
+    .from('purchase_orders')
+    .update(baseUpdate)
+    .eq('id', quotation.purchase_order_id)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Coordinators could open **Editar cotización**, save successfully, and still see **unchanged amounts on the purchase order**. The quotation row was updating; the PO header was not.

## Root cause

When a quote is **selected**, `select_quotation()` copies `quoted_amount`, `supplier`, `items`, and `approval_amount` onto `purchase_orders`.

`PATCH /api/purchase-orders/quotations/[id]` only updated `purchase_order_quotations`. The PO detail page (`/compras/[id]`) displays **`order.total_amount`** and **`order.approval_amount`** from the PO row, so coordinators perceived the edit as not saved.

## Fix

After a successful PATCH, if the quote is the winning one (`status = selected` or `selected_quotation_id` matches), sync the same fields onto `purchase_orders` via `syncPurchaseOrderFromSelectedQuotation()`.

Also:
- Refresh workflow UI (`quotationSelected` event + `router.refresh()`)
- Clearer success toast when the selected quote was edited
- Rejected-quote edit + mobile coordinator gate (from prior commit)

## How to verify

1. Open a PO with a **selected** quotation as Coordinador
2. Edit amount/supplier → Guardar
3. Confirm PO header total and quotation card both show the new values after reload
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb27c34d-6380-407e-8848-5a6d00280f46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb27c34d-6380-407e-8848-5a6d00280f46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

