### PR TITLE
fix(reportes): repair mantto drill-down and add diesel L/m³ metric

### DIFF
--- a/app/api/reports/gerencial/ingresos-gastos/operational-details/route.ts
+++ b/app/api/reports/gerencial/ingresos-gastos/operational-details/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { runGerencialReport } from '@/lib/reports/run-gerencial-report'
 import {
   aggregateDieselByPlant,
   buildManttoBreakdownFromGerencial,
@@ -7,8 +6,12 @@ import {
   type DieselOperationalDetails,
   type ManttoOperationalDetails,
 } from '@/lib/reports/ingresos-gastos-operational-details'
+import { fetchManttoOperationalBreakdown } from '@/lib/reports/mantto-operational-fetch'
 import type { AnomalyFlags } from '@/components/reports/diesel-efficiency/types'
 import { requireReportsApiAccess } from '@/lib/reports/report-api-auth'
+
+/** Mantto path runs scoped PO queries; allow headroom on Vercel. */
+export const maxDuration = 120
 
 export async function GET(req: NextRequest) {
   try {
@@ -58,8 +61,6 @@ export async function GET(req: NextRequest) {
       )
     }
 
-    const requestHost = req.headers.get('host')
-
     if (category === 'diesel') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sb = supabase as any
@@ -93,31 +94,14 @@ export async function GET(req: NextRequest) {
     }
 
     const { dateFromStr, dateToStr } = getMonthDateRange(month)
-    const gerencialData = await runGerencialReport(
-      {
-        dateFrom: dateFromStr,
-        dateTo: dateToStr,
-        businessUnitId,
-        plantId,
-        hideZeroActivity: false,
-      },
-      { requestHost, supabase }
-    )
-
-    const plants = (gerencialData.plants || []) as Array<{
-      id: string
-      maintenance_cost?: number
-      preventive_cost?: number
-      corrective_cost?: number
-    }>
-    const assets = (gerencialData.assets || []) as Array<{
-      id: string
-      asset_code?: string
-      plant_id?: string
-      preventive_cost?: number
-      corrective_cost?: number
-      maintenance_cost?: number
-    }>
+    const { plants, assets } = await fetchManttoOperationalBreakdown({
+      supabase,
+      dateFromStr,
+      dateToStr,
+      scopePlantIds,
+      businessUnitId,
+      plantId,
+    })
 
     const byPlantId = buildManttoBreakdownFromGerencial(plants, assets, scopePlantIds)
     const payload: ManttoOperationalDetails = { category: 'mantto', byPlantId }

--- a/components/reports/cost-analysis/drilldown/metric-drilldown-sheet.tsx
+++ b/components/reports/cost-analysis/drilldown/metric-drilldown-sheet.tsx
@@ -106,7 +106,9 @@ function DrilldownBody({
     }))
 
   if (metric === 'diesel' && dieselDetails) {
-    return <DieselPanel month={month} plants={plantRows} details={dieselDetails} />
+    return (
+      <DieselPanel month={month} plants={plantRows} details={dieselDetails} data={data} />
+    )
   }
   if (metric === 'mantto') {
     return (
@@ -196,23 +198,28 @@ function DieselPanel({
   month,
   plants,
   details,
+  data,
 }: {
   month: string
   plants: Array<{ id: string; code: string; name: string }>
   details: DieselOperationalDetails
+  data: CostAnalysisResponse
 }) {
   const rows = plants
     .map(p => {
       const d = details.byPlantId[p.id]
       if (!d || d.total_liters <= 0) return null
+      const volume = data.byPlant.find(bp => bp.plantId === p.id)?.volume[month] ?? 0
+      const lpm3 = volume > 0 ? d.total_liters / volume : null
+      const lpm3Part = lpm3 != null ? `${formatNumber(lpm3, 2)} L/m³` : null
+      const lphPart =
+        d.avg_lph_trusted != null ? `${formatNumber(d.avg_lph_trusted, 1)} L/h` : null
+      const subParts = [lpm3Part, lphPart, `${d.assets_with_data} activos`].filter(Boolean)
       return {
         key: p.id,
         label: `${p.code} · ${p.name}`,
         value: `${formatNumber(d.total_liters, 0)} L`,
-        sub:
-          d.avg_lph_trusted != null
-            ? `${formatNumber(d.avg_lph_trusted, 1)} L/h · ${d.assets_with_data} activos`
-            : `${d.assets_with_data} activos`,
+        sub: subParts.join(' · '),
       }
     })
     .filter(Boolean) as Array<{ key: string; label: string; value: string; sub?: string }>

--- a/components/reports/ingresos-gastos/diesel-expansion-rows.tsx
+++ b/components/reports/ingresos-gastos/diesel-expansion-rows.tsx
@@ -99,6 +99,24 @@ export function DieselExpansionRows({
         plants.reduce((s, p) => s + (get(p.plant_id)?.total_liters ?? 0), 0),
     },
     {
+      label: '↳ L/m³ concreto',
+      isAverage: false,
+      getPlantValue: pid => {
+        const liters = get(pid)?.total_liters ?? 0
+        const vol = plants.find(p => p.plant_id === pid)?.volumen_concreto ?? 0
+        return vol > 0 ? liters / vol : null
+      },
+      formatFn: v => (v != null ? `${formatNumber(v, 2)} L/m³` : '—'),
+      aggregateGrand: () => {
+        const totalLiters = plants.reduce(
+          (s, p) => s + (get(p.plant_id)?.total_liters ?? 0),
+          0
+        )
+        const totalVol = plants.reduce((s, p) => s + (p.volumen_concreto ?? 0), 0)
+        return totalVol > 0 ? totalLiters / totalVol : null
+      },
+    },
+    {
       label: '↳ L/h promedio flota',
       isAverage: true,
       getPlantValue: pid => get(pid)?.avg_lph_trusted ?? null,

--- a/components/reports/ingresos-gastos/operational-expansion-types.ts
+++ b/components/reports/ingresos-gastos/operational-expansion-types.ts
@@ -5,4 +5,5 @@ export type PlantData = {
   business_unit_id: string
   mantto_total: number
   diesel_total: number
+  volumen_concreto: number
 }

--- a/lib/reports/ingresos-gastos-operational-details.ts
+++ b/lib/reports/ingresos-gastos-operational-details.ts
@@ -108,14 +108,14 @@ export function aggregateDieselByPlant(
   return result
 }
 
-type GerencialPlantLike = {
+export type GerencialPlantLike = {
   id: string
   maintenance_cost?: number
   preventive_cost?: number
   corrective_cost?: number
 }
 
-type GerencialAssetLike = {
+export type GerencialAssetLike = {
   id: string
   asset_code?: string
   plant_id?: string

--- a/lib/reports/mantto-operational-fetch.ts
+++ b/lib/reports/mantto-operational-fetch.ts
@@ -1,0 +1,301 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/supabase-types'
+import { buildAssignmentHistoryMap, resolveAssetPlantAtTimestamp } from '@/lib/reporting/asset-plant-attribution'
+import { shouldIncludePurchaseOrderInExpenseReport } from '@/lib/reports/purchase-order-report-eligibility'
+import type {
+  GerencialAssetLike,
+  GerencialPlantLike,
+} from '@/lib/reports/ingresos-gastos-operational-details'
+
+type ManttoSupabase = SupabaseClient<Database>
+
+type PurchaseOrderRow = {
+  id: string
+  total_amount: string | number | null
+  actual_amount: string | number | null
+  created_at: string
+  posting_date?: string | null
+  purchase_date?: string | null
+  plant_id?: string | null
+  work_order_id?: string | null
+  status: string | null
+  po_purpose?: string | null
+}
+
+type WorkOrderRow = {
+  id: string
+  type: string | null
+  asset_id: string | null
+  planned_date?: string | null
+  completed_at?: string | null
+  created_at?: string | null
+}
+
+function extractDateOnly(dateStr: string): string {
+  if (!dateStr) return ''
+  if (dateStr.includes('T')) return dateStr.split('T')[0]
+  return dateStr.slice(0, 10)
+}
+
+function poAmount(po: PurchaseOrderRow): number {
+  const raw = po.actual_amount != null ? po.actual_amount : po.total_amount
+  const n = parseFloat(String(raw ?? '0'))
+  return Number.isFinite(n) ? n : 0
+}
+
+function poInDateRange(
+  po: PurchaseOrderRow,
+  wo: WorkOrderRow | undefined,
+  dateFromStr: string,
+  dateToStr: string
+): boolean {
+  let dateToCheckStr = ''
+  if (po.purchase_date) dateToCheckStr = po.purchase_date
+  else if (po.work_order_id && wo) {
+    if (wo.completed_at) dateToCheckStr = wo.completed_at
+    else if (wo.planned_date) dateToCheckStr = wo.planned_date
+    else if (wo.created_at) dateToCheckStr = wo.created_at
+    else dateToCheckStr = po.created_at
+  } else {
+    dateToCheckStr = po.created_at
+  }
+  const dOnly = extractDateOnly(dateToCheckStr)
+  return dOnly >= dateFromStr && dOnly <= dateToStr
+}
+
+/**
+ * Scoped maintenance breakdown for ingresos-gastos operational drill-down.
+ * Matches gerencial PO rules without running the full gerencial report (diesel, sales, FIFO).
+ */
+export async function fetchManttoOperationalBreakdown(params: {
+  supabase: ManttoSupabase
+  dateFromStr: string
+  dateToStr: string
+  scopePlantIds: Set<string>
+  businessUnitId?: string | null
+  plantId?: string | null
+}): Promise<{ plants: GerencialPlantLike[]; assets: GerencialAssetLike[] }> {
+  const { supabase, dateFromStr, dateToStr, scopePlantIds, businessUnitId, plantId } = params
+
+  let scopedPlantIds = Array.from(scopePlantIds)
+  if (plantId) scopedPlantIds = scopedPlantIds.filter(id => id === plantId)
+  if (scopedPlantIds.length === 0) {
+    return { plants: [], assets: [] }
+  }
+
+  let plantsQuery = supabase
+    .from('plants')
+    .select('id, name, code, business_unit_id')
+    .in('id', scopedPlantIds)
+
+  if (businessUnitId) plantsQuery = plantsQuery.eq('business_unit_id', businessUnitId)
+
+  const { data: plantsRows, error: plantsErr } = await plantsQuery
+  if (plantsErr) throw plantsErr
+
+  const plantsInScope = (plantsRows || []).filter(p => scopePlantIds.has(p.id))
+  const plantIds = plantsInScope.map(p => p.id)
+  if (plantIds.length === 0) return { plants: [], assets: [] }
+
+  const { data: rawAssets, error: assetsErr } = await supabase
+    .from('assets')
+    .select('id, asset_id, name, plant_id')
+    .in('plant_id', plantIds)
+
+  if (assetsErr) throw assetsErr
+
+  const assetIds = (rawAssets || []).map(a => a.id)
+  const attributionDate = `${dateToStr}T23:59:59.999Z`
+
+  let assignmentRows: Array<{
+    asset_id: string
+    previous_plant_id: string | null
+    new_plant_id: string | null
+    created_at: string
+  }> = []
+
+  if (assetIds.length > 0) {
+    const { data, error: assignmentError } = await supabase
+      .from('asset_assignment_history')
+      .select('asset_id, previous_plant_id, new_plant_id, created_at')
+      .in('asset_id', assetIds)
+      .order('created_at', { ascending: true })
+    if (assignmentError) throw assignmentError
+    assignmentRows = data || []
+  }
+
+  const historyByAsset = buildAssignmentHistoryMap(assignmentRows)
+
+  const assetMap = new Map<
+    string,
+    {
+      id: string
+      asset_code: string
+      plant_id: string
+      maintenance_cost: number
+      preventive_cost: number
+      corrective_cost: number
+    }
+  >()
+
+  for (const asset of rawAssets || []) {
+    const attributedPlantId = resolveAssetPlantAtTimestamp({
+      assetId: asset.id,
+      eventDate: attributionDate,
+      currentPlantId: asset.plant_id,
+      historyByAsset,
+    })
+    if (!attributedPlantId || !scopePlantIds.has(attributedPlantId)) continue
+
+    assetMap.set(asset.id, {
+      id: asset.id,
+      asset_code: asset.asset_id || asset.id.slice(0, 8),
+      plant_id: attributedPlantId,
+      maintenance_cost: 0,
+      preventive_cost: 0,
+      corrective_cost: 0,
+    })
+  }
+
+  const scopedAssetIds = Array.from(assetMap.keys())
+  const workOrdersMap = new Map<string, WorkOrderRow>()
+
+  const CHUNK = 200
+  if (scopedAssetIds.length > 0) {
+    for (let i = 0; i < scopedAssetIds.length; i += CHUNK) {
+      const chunk = scopedAssetIds.slice(i, i + CHUNK)
+      const { data: workOrders, error: woErr } = await supabase
+        .from('work_orders')
+        .select('id, type, asset_id, planned_date, completed_at, created_at')
+        .in('asset_id', chunk)
+      if (woErr) throw woErr
+      for (const wo of workOrders || []) {
+        workOrdersMap.set(wo.id, wo)
+      }
+    }
+  }
+
+  const workOrderIds = Array.from(workOrdersMap.keys())
+  const purchaseOrders: PurchaseOrderRow[] = []
+
+  for (let i = 0; i < workOrderIds.length; i += CHUNK) {
+    const chunk = workOrderIds.slice(i, i + CHUNK)
+    const { data: pos, error: poErr } = await supabase
+      .from('purchase_orders')
+      .select(
+        'id, total_amount, actual_amount, created_at, posting_date, purchase_date, plant_id, work_order_id, status, po_purpose'
+      )
+      .in('work_order_id', chunk)
+    if (poErr) throw poErr
+    purchaseOrders.push(...((pos || []) as PurchaseOrderRow[]))
+  }
+
+  for (let i = 0; i < plantIds.length; i += CHUNK) {
+    const chunk = plantIds.slice(i, i + CHUNK)
+    const { data: standalonePos, error: standaloneErr } = await supabase
+      .from('purchase_orders')
+      .select(
+        'id, total_amount, actual_amount, created_at, posting_date, purchase_date, plant_id, work_order_id, status, po_purpose'
+      )
+      .is('work_order_id', null)
+      .in('plant_id', chunk)
+    if (standaloneErr) throw standaloneErr
+    purchaseOrders.push(...((standalonePos || []) as PurchaseOrderRow[]))
+  }
+
+  const eligible = purchaseOrders.filter(po =>
+    shouldIncludePurchaseOrderInExpenseReport({ status: po.status })
+  )
+
+  const workOrderPOs = eligible.filter(
+    po => po.work_order_id && po.po_purpose !== 'inventory_restock'
+  )
+  const standalonePOs = eligible.filter(
+    po => !po.work_order_id && po.po_purpose !== 'inventory_restock' && po.plant_id
+  )
+
+  for (const po of workOrderPOs) {
+    const wo = po.work_order_id ? workOrdersMap.get(po.work_order_id) : undefined
+    if (!wo?.asset_id) continue
+    if (!poInDateRange(po, wo, dateFromStr, dateToStr)) continue
+
+    const asset = assetMap.get(wo.asset_id)
+    if (!asset) continue
+
+    const amount = poAmount(po)
+    if (amount === 0) continue
+
+    asset.maintenance_cost += amount
+    if (wo.type === 'preventive') asset.preventive_cost += amount
+    else asset.corrective_cost += amount
+  }
+
+  const plantMap = new Map<
+    string,
+    {
+      id: string
+      maintenance_cost: number
+      preventive_cost: number
+      corrective_cost: number
+    }
+  >()
+
+  for (const plant of plantsInScope) {
+    plantMap.set(plant.id, {
+      id: plant.id,
+      maintenance_cost: 0,
+      preventive_cost: 0,
+      corrective_cost: 0,
+    })
+  }
+
+  assetMap.forEach(asset => {
+    const plant = plantMap.get(asset.plant_id)
+    if (!plant) return
+    plant.maintenance_cost += asset.maintenance_cost
+    plant.preventive_cost += asset.preventive_cost
+    plant.corrective_cost += asset.corrective_cost
+  })
+
+  for (const po of standalonePOs) {
+    const plantId = po.plant_id
+    if (!plantId || !scopePlantIds.has(plantId)) continue
+    if (!poInDateRange(po, undefined, dateFromStr, dateToStr)) continue
+
+    let plant = plantMap.get(plantId)
+    if (!plant) {
+      plant = {
+        id: plantId,
+        maintenance_cost: 0,
+        preventive_cost: 0,
+        corrective_cost: 0,
+      }
+      plantMap.set(plantId, plant)
+    }
+    const amount = poAmount(po)
+    plant.maintenance_cost += amount
+    plant.corrective_cost += amount
+  }
+
+  const plants: GerencialPlantLike[] = []
+  for (const plantId of scopePlantIds) {
+    const p = plantMap.get(plantId)
+    plants.push({
+      id: plantId,
+      maintenance_cost: p?.maintenance_cost ?? 0,
+      preventive_cost: p?.preventive_cost ?? 0,
+      corrective_cost: p?.corrective_cost ?? 0,
+    })
+  }
+
+  const assets: GerencialAssetLike[] = Array.from(assetMap.values()).map(a => ({
+    id: a.id,
+    asset_code: a.asset_code,
+    plant_id: a.plant_id,
+    preventive_cost: a.preventive_cost,
+    corrective_cost: a.corrective_cost,
+    maintenance_cost: a.maintenance_cost,
+  }))
+
+  return { plants, assets }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Expanding **MANTTO** on Ingresos vs Gastos (and the cost-analysis mantto drill-down) called `runGerencialReport()` for operational details. That full report loads all purchase orders, runs diesel FIFO, cotizador sales, and merged hours — often exceeding the default serverless timeout, so the drill-down failed to load.

## Solution

### Maintenance drill-down
- New scoped fetch: `lib/reports/mantto-operational-fetch.ts`
  - Loads only plants/assets in `scopePlantIds`
  - Applies the same PO status eligibility and date precedence as gerencial
  - Splits preventive vs corrective and supports unallocated corrective (via existing `buildManttoBreakdownFromGerencial`)
- `operational-details` route uses this path for `category=mantto` and sets `maxDuration = 120`

### Diesel drill-down
- New row on Ingresos vs Gastos expansion: **↳ L/m³ concreto** = total liters ÷ `volumen_concreto` for the month (plant and grand total)
- Cost analysis diesel sheet shows L/m³ in the subtitle when volume is available

## Testing
- `node --test lib/reports/ingresos-gastos-operational-details.test.ts` (existing tests pass)

## How to verify
1. Open `/reportes/gerencial/ingresos-gastos`, pick a month with mantto spend
2. Expand **MANTTO. (Todas las Unidades)** — preventive/corrective rows should load without error
3. Expand **Diesel** — confirm **L/m³ concreto** appears next to liters and L/h metrics
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8cd162d-7180-4cf9-a307-de3a7bf49667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8cd162d-7180-4cf9-a307-de3a7bf49667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

