### PR TITLE
Fix diesel efficiency report hardcoded month range (May 2026 cap)

### DIFF
--- a/app/api/reports/asset-diesel-efficiency/route.ts
+++ b/app/api/reports/asset-diesel-efficiency/route.ts
@@ -2,6 +2,7 @@ import { createClient } from '@supabase/supabase-js'
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { computeAssetDieselEfficiencyMonths } from '@/lib/reports/compute-asset-diesel-efficiency-monthly'
+import { dieselEfficiencyReportMonths } from '@/lib/reports/month-utils'
 import {
   canRecomputeDieselEfficiency,
   requireReportsApiAccess,
@@ -92,7 +93,7 @@ export async function POST(req: NextRequest) {
     const yearMonths =
       body.yearMonths && body.yearMonths.length > 0
         ? body.yearMonths
-        : ['2026-01', '2026-02', '2026-03', '2026-04']
+        : dieselEfficiencyReportMonths()
 
     const url = process.env.NEXT_PUBLIC_SUPABASE_URL
     const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY

--- a/app/reportes/eficiencia-diesel/page.tsx
+++ b/app/reportes/eficiencia-diesel/page.tsx
@@ -24,22 +24,18 @@ import { DrillSheet } from '@/components/reports/diesel-efficiency/drill-sheet'
 import { AnomaliesList } from '@/components/reports/diesel-efficiency/anomalies-list'
 import { DataQualityList } from '@/components/reports/diesel-efficiency/data-quality-list'
 import type { EfficiencyRow, ViewMode } from '@/components/reports/diesel-efficiency/types'
+import {
+  dieselEfficiencyReportMonths,
+  formatYearMonthLabelEs,
+  formatYearMonthRangeLabelEs,
+  mexicoCityYearMonth,
+  shiftMonthString,
+} from '@/lib/reports/month-utils'
 
-const MONTHS = ['2026-05', '2026-04', '2026-03', '2026-02', '2026-01']
-const MONTHS_LABEL: Record<string, string> = {
-  '2026-05': 'Mayo 2026',
-  '2026-04': 'Abril 2026',
-  '2026-03': 'Marzo 2026',
-  '2026-02': 'Febrero 2026',
-  '2026-01': 'Enero 2026',
-}
-
-function prevMonth(ym: string): string {
-  const [ys, ms] = ym.split('-')
-  let y = Number(ys)
-  let m = Number(ms) - 1
-  if (m === 0) { m = 12; y-- }
-  return `${y}-${String(m).padStart(2, '0')}`
+function resolveInitialYearMonth(searchMonth: string | null): string {
+  const available = dieselEfficiencyReportMonths()
+  if (searchMonth && available.includes(searchMonth)) return searchMonth
+  return mexicoCityYearMonth()
 }
 
 function downloadCsv(filename: string, header: string[], lines: (string | number | null | undefined)[][]) {
@@ -66,7 +62,13 @@ function EficienciaDieselContent() {
   const searchParams = useSearchParams()
   const router = useRouter()
 
-  const [yearMonth, setYearMonth] = useState(() => searchParams.get('mes') ?? '2026-05')
+  const reportMonths = useMemo(() => dieselEfficiencyReportMonths(), [])
+  const recomputeRangeLabel = useMemo(
+    () => formatYearMonthRangeLabelEs(reportMonths[reportMonths.length - 1]!, reportMonths[0]!),
+    [reportMonths]
+  )
+
+  const [yearMonth, setYearMonth] = useState(() => resolveInitialYearMonth(searchParams.get('mes')))
   const [selectedBu, setSelectedBu] = useState<string | null>(null)
   const [selectedPlant, setSelectedPlant] = useState<string | null>(null)
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
@@ -122,7 +124,7 @@ function EficienciaDieselContent() {
     try {
       const [curr, prev] = await Promise.all([
         loadRows(yearMonth),
-        loadRows(prevMonth(yearMonth)),
+        loadRows(shiftMonthString(yearMonth, -1)),
       ])
       setRows(curr)
       setPrevRows(prev)
@@ -149,7 +151,7 @@ function EficienciaDieselContent() {
       const r = await fetch('/api/reports/asset-diesel-efficiency', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ yearMonths: MONTHS, recompute: true }),
+        body: JSON.stringify({ yearMonths: reportMonths, recompute: true }),
       })
       const j = await r.json()
       if (!r.ok) throw new Error(j.error || 'Error al recalcular')
@@ -296,7 +298,7 @@ function EficienciaDieselContent() {
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="text-sm">
                 <DropdownMenuItem onClick={() => void onRecompute()} disabled={recomputing}>
-                  {recomputing ? 'Recalculando…' : 'Recalcular Ene–May 2026'}
+                  {recomputing ? 'Recalculando…' : `Recalcular ${recomputeRangeLabel}`}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -323,8 +325,8 @@ function EficienciaDieselContent() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {MONTHS.map((m) => (
-                <SelectItem key={m} value={m} className="text-xs">{MONTHS_LABEL[m] ?? m}</SelectItem>
+              {reportMonths.map((m) => (
+                <SelectItem key={m} value={m} className="text-xs">{formatYearMonthLabelEs(m)}</SelectItem>
               ))}
             </SelectContent>
           </Select>
@@ -466,7 +468,7 @@ function EficienciaDieselContent() {
                   <Fuel className="h-5 w-5 text-stone-400" />
                 </div>
                 <div>
-                  <p className="font-semibold text-stone-700">Sin datos para {MONTHS_LABEL[yearMonth] ?? yearMonth}</p>
+                  <p className="font-semibold text-stone-700">Sin datos para {formatYearMonthLabelEs(yearMonth)}</p>
                   <p className="text-sm text-stone-400 mt-1 max-w-md">
                     Primero aplica la migración en Supabase, luego ejecuta el backfill o usa
                     «Recalcular» en el menú ⋯ para calcular las métricas de este mes.

--- a/components/diesel-analytics/horometer-validation-tab.tsx
+++ b/components/diesel-analytics/horometer-validation-tab.tsx
@@ -22,6 +22,11 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Info, Loader2 } from "lucide-react"
+import {
+  dieselEfficiencyReportMonths,
+  formatYearMonthLabelEs,
+  mexicoCityYearMonth,
+} from "@/lib/reports/month-utils"
 
 export type WarehouseOpt = { id: string; name: string }
 
@@ -65,11 +70,6 @@ type TrustedEffRow = {
   liters_per_hour_trusted: number | null
 }
 
-function defaultYearMonth(): string {
-  const d = new Date()
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
-}
-
 function parseAssetSelection(value: string): { assetId: string | null; exceptionName: string | null } {
   if (value.startsWith("asset:")) return { assetId: value.slice(6), exceptionName: null }
   if (value.startsWith("ext:")) return { assetId: null, exceptionName: decodeURIComponent(value.slice(4)) }
@@ -77,7 +77,8 @@ function parseAssetSelection(value: string): { assetId: string | null; exception
 }
 
 export function HorometerValidationTab({ warehouses }: { warehouses: WarehouseOpt[] }) {
-  const [yearMonth, setYearMonth] = useState(defaultYearMonth)
+  const reportMonths = useMemo(() => dieselEfficiencyReportMonths(), [])
+  const [yearMonth, setYearMonth] = useState(mexicoCityYearMonth)
   const [warehouseId, setWarehouseId] = useState<string>(warehouses[0]?.id ?? "")
   const [assetValue, setAssetValue] = useState<string>("")
 
@@ -253,9 +254,9 @@ export function HorometerValidationTab({ warehouses }: { warehouses: WarehouseOp
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {["2026-01", "2026-02", "2026-03", "2026-04", "2026-05", "2026-06"].map((ym) => (
+                {reportMonths.map((ym) => (
                   <SelectItem key={ym} value={ym}>
-                    {ym}
+                    {formatYearMonthLabelEs(ym)}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/components/reports/diesel-efficiency/drill-sheet.tsx
+++ b/components/reports/diesel-efficiency/drill-sheet.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/lib/reports/merged-operating-hours'
 import { buildMergedKmReadingEventsForAsset } from '@/lib/reports/merged-operating-km'
 import { mexicoCityMonthWindowFromYm } from '@/lib/reports/mexico-city-report-window'
+import { mexicoCityYearMonth, shiftMonthString } from '@/lib/reports/month-utils'
 
 type TrendPoint = {
   month: string
@@ -1044,20 +1045,6 @@ type RemisionRow = {
   cancelled_reason: string | null
 }
 
-function prevMonth(ym: string): string {
-  const [ys, ms] = ym.split('-')
-  let y = Number(ys), m = Number(ms) - 1
-  if (m === 0) { m = 12; y-- }
-  return `${y}-${String(m).padStart(2, '0')}`
-}
-
-function nextMonth(ym: string): string {
-  const [ys, ms] = ym.split('-')
-  let y = Number(ys), m = Number(ms) + 1
-  if (m === 13) { m = 1; y++ }
-  return `${y}-${String(m).padStart(2, '0')}`
-}
-
 export function DrillSheet({ row, yearMonth, open, onOpenChange, onDataChanged }: Props) {
   const [activeYearMonth, setActiveYearMonth] = useState(yearMonth)
   const [events, setEvents] = useState<MeterEvent[]>([])
@@ -1416,7 +1403,7 @@ export function DrillSheet({ row, yearMonth, open, onOpenChange, onDataChanged }
 
   const assetLabel = [row.assets?.asset_id, row.assets?.name].filter(Boolean).join(' — ')
   const isCurrentMonth = activeYearMonth === yearMonth
-  const isFutureMonth = activeYearMonth > new Date().toISOString().slice(0, 7)
+  const isFutureMonth = activeYearMonth > mexicoCityYearMonth()
 
   return (
     <>
@@ -1434,7 +1421,7 @@ export function DrillSheet({ row, yearMonth, open, onOpenChange, onDataChanged }
                 {/* Month navigator */}
                 <div className="flex items-center gap-1">
                   <button
-                    onClick={() => setActiveYearMonth(prevMonth(activeYearMonth))}
+                    onClick={() => setActiveYearMonth(shiftMonthString(activeYearMonth, -1))}
                     className="p-0.5 rounded hover:bg-stone-200 text-stone-400 hover:text-stone-700 transition-colors"
                     title="Mes anterior"
                   >
@@ -1444,7 +1431,7 @@ export function DrillSheet({ row, yearMonth, open, onOpenChange, onDataChanged }
                     {activeYearMonth}
                   </span>
                   <button
-                    onClick={() => setActiveYearMonth(nextMonth(activeYearMonth))}
+                    onClick={() => setActiveYearMonth(shiftMonthString(activeYearMonth, 1))}
                     disabled={isFutureMonth}
                     className="p-0.5 rounded hover:bg-stone-200 text-stone-400 hover:text-stone-700 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                     title="Mes siguiente"

--- a/lib/reports/month-utils.test.ts
+++ b/lib/reports/month-utils.test.ts
@@ -1,7 +1,14 @@
 import test from "node:test"
 import assert from "node:assert/strict"
 
-import { shiftMonthString } from "./month-utils"
+import {
+  dieselEfficiencyReportMonths,
+  formatYearMonthLabelEs,
+  formatYearMonthRangeLabelEs,
+  listYearMonthsDescending,
+  mexicoCityYearMonth,
+  shiftMonthString,
+} from "./month-utils"
 
 test("shifts a YYYY-MM month string backward without timezone drift", () => {
   assert.equal(shiftMonthString("2026-03", -1), "2026-02")
@@ -10,4 +17,35 @@ test("shifts a YYYY-MM month string backward without timezone drift", () => {
 
 test("shifts a YYYY-MM month string forward across year boundaries", () => {
   assert.equal(shiftMonthString("2025-12", 1), "2026-01")
+})
+
+test("mexicoCityYearMonth uses America/Mexico_City calendar", () => {
+  // June 1 2026 05:30 UTC = May 31 2026 23:30 Mexico City
+  assert.equal(mexicoCityYearMonth(new Date("2026-06-01T05:30:00.000Z")), "2026-05")
+  assert.equal(mexicoCityYearMonth(new Date("2026-06-01T06:30:00.000Z")), "2026-06")
+})
+
+test("listYearMonthsDescending returns newest-first inclusive range", () => {
+  assert.deepEqual(listYearMonthsDescending("2026-01", "2026-03"), [
+    "2026-03",
+    "2026-02",
+    "2026-01",
+  ])
+})
+
+test("dieselEfficiencyReportMonths grows through current Mexico City month", () => {
+  const june = new Date("2026-06-15T12:00:00.000Z")
+  assert.deepEqual(dieselEfficiencyReportMonths(june), [
+    "2026-06",
+    "2026-05",
+    "2026-04",
+    "2026-03",
+    "2026-02",
+    "2026-01",
+  ])
+})
+
+test("formatYearMonthLabelEs and range label", () => {
+  assert.equal(formatYearMonthLabelEs("2026-06"), "Junio 2026")
+  assert.equal(formatYearMonthRangeLabelEs("2026-01", "2026-06"), "Ene–Jun 2026")
 })

--- a/lib/reports/month-utils.ts
+++ b/lib/reports/month-utils.ts
@@ -1,7 +1,96 @@
+import { REPORTS_CALENDAR_TIMEZONE } from '@/lib/reports/mexico-city-report-window'
+
 export function shiftMonthString(month: string, delta: number): string {
   const [year, monthNumber] = month.split("-").map(Number)
   if (!year || !monthNumber) return month
 
   const shifted = new Date(year, monthNumber - 1 + delta, 1)
   return `${shifted.getFullYear()}-${String(shifted.getMonth() + 1).padStart(2, "0")}`
+}
+
+/** Current `YYYY-MM` in the reporting calendar (America/Mexico_City). */
+export function mexicoCityYearMonth(referenceDate = new Date()): string {
+  const dateOnly = referenceDate.toLocaleDateString('sv-SE', { timeZone: REPORTS_CALENDAR_TIMEZONE })
+  return dateOnly.slice(0, 7)
+}
+
+const MONTH_NAMES_ES = [
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
+] as const
+
+const MONTH_NAMES_ES_SHORT = [
+  'Ene',
+  'Feb',
+  'Mar',
+  'Abr',
+  'May',
+  'Jun',
+  'Jul',
+  'Ago',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dic',
+] as const
+
+/** Human label for a `YYYY-MM` value, e.g. `Junio 2026`. */
+export function formatYearMonthLabelEs(ym: string, short = false): string {
+  const [ys, ms] = ym.split('-')
+  const monthIndex = Number(ms) - 1
+  if (!ys || monthIndex < 0 || monthIndex > 11) return ym
+  const names = short ? MONTH_NAMES_ES_SHORT : MONTH_NAMES_ES
+  return `${names[monthIndex]} ${ys}`
+}
+
+/** Inclusive `YYYY-MM` range, newest first (for month pickers). */
+export function listYearMonthsDescending(fromYm: string, toYm: string): string[] {
+  let from = fromYm.slice(0, 7)
+  let to = toYm.slice(0, 7)
+  if (from > to) [from, to] = [to, from]
+
+  const out: string[] = []
+  let cur = to
+  for (let i = 0; i < 240; i++) {
+    out.push(cur)
+    if (cur === from) break
+    cur = shiftMonthString(cur, -1)
+  }
+  return out
+}
+
+/** First month with diesel efficiency rollups in production. */
+export const DIESEL_EFFICIENCY_REPORT_START_YM = '2026-01'
+
+/** Months available in the diesel efficiency report UI (start → current Mexico City month). */
+export function dieselEfficiencyReportMonths(referenceDate = new Date()): string[] {
+  return listYearMonthsDescending(
+    DIESEL_EFFICIENCY_REPORT_START_YM,
+    mexicoCityYearMonth(referenceDate)
+  )
+}
+
+/** Label for bulk recompute actions, e.g. `Ene–Jun 2026`. */
+export function formatYearMonthRangeLabelEs(fromYm: string, toYm: string): string {
+  const from = fromYm.slice(0, 7)
+  const to = toYm.slice(0, 7)
+  if (from === to) return formatYearMonthLabelEs(from)
+  const [fromYear, fromMonth] = from.split('-')
+  const [toYear, toMonth] = to.split('-')
+  const fromIdx = Number(fromMonth) - 1
+  const toIdx = Number(toMonth) - 1
+  if (fromYear === toYear && fromIdx >= 0 && toIdx >= 0) {
+    return `${MONTH_NAMES_ES_SHORT[fromIdx]}–${MONTH_NAMES_ES_SHORT[toIdx]} ${toYear}`
+  }
+  return `${formatYearMonthLabelEs(from, true)} – ${formatYearMonthLabelEs(to, true)}`
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The diesel efficiency report (`/reportes/eficiencia-diesel`) was hardcoded to only show months through **May 2026**, with May as the default. As we move into June and beyond, the UI could not select or display current-month data.

## Solution

Introduced shared month utilities in `lib/reports/month-utils.ts`:

- `mexicoCityYearMonth()` — current `YYYY-MM` in `America/Mexico_City`
- `dieselEfficiencyReportMonths()` — rolling list from `2026-01` through the current Mexico City month
- `formatYearMonthLabelEs()` / `formatYearMonthRangeLabelEs()` — Spanish labels for pickers and recompute actions

Updated:

- **Eficiencia diésel page** — dynamic month picker, default to current month, recompute covers full available range
- **API POST default** — uses the same rolling month list when `yearMonths` is omitted
- **Drill sheet** — future-month guard uses Mexico City calendar
- **Horómetro validation tab** — same dynamic month list for consistency

## Testing

- `npx tsx --test lib/reports/month-utils.test.ts` — all 6 tests pass

## Note

After deploying, use **Recalcular Ene–Jun 2026** (or the current range) once to populate June rollup rows if they are not yet in `asset_diesel_efficiency_monthly`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f60adf90-d88c-4a28-a06f-6e1c8ab2162a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f60adf90-d88c-4a28-a06f-6e1c8ab2162a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

