### PR TITLE
Allow Dosificador to access eficiencia diésel report

### DIFF
--- a/app/(dashboard)/dashboard/dosificador/page.tsx
+++ b/app/(dashboard)/dashboard/dosificador/page.tsx
@@ -3,7 +3,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { AlertTriangle, ClipboardList, Fuel, Loader2, RefreshCw } from "lucide-react"
+import { AlertTriangle, BarChart3, ClipboardList, Fuel, Loader2, RefreshCw } from "lucide-react"
+import { reportShortcutsForRole } from "@/lib/reports/executive-dashboard-shortcuts"
 import { Button } from "@/components/ui/button"
 import { PullToRefresh } from "@/components/ui/pull-to-refresh"
 import { useAuthZustand } from "@/hooks/use-auth-zustand"
@@ -84,9 +85,18 @@ export default function DosificadorDashboard() {
     [payload?.assetsForIncidents]
   )
 
+  const reportShortcuts =
+    profile?.role === "DOSIFICADOR" ? reportShortcutsForRole(profile.role, profile) : []
+
   const moduleCards = [
     { title: "Diésel", href: "/diesel", icon: Fuel, module: "inventory" as const },
     { title: "Checklists", href: "/checklists", icon: ClipboardList, module: "checklists" as const },
+    ...reportShortcuts.map((s) => ({
+      title: s.label,
+      href: s.href,
+      icon: BarChart3,
+      module: "inventory" as const,
+    })),
   ]
 
   if (!isInitialized || (authLoading && !profile)) {
@@ -150,6 +160,11 @@ export default function DosificadorDashboard() {
             href: "/dashboard/operator/incidentes?estado=abiertos",
             icon: <AlertTriangle className="h-4 w-4" />,
           },
+          ...reportShortcuts.map((s) => ({
+            label: s.label,
+            href: s.href,
+            icon: <BarChart3 className="h-4 w-4" />,
+          })),
         ]}
         kpis={
           <div className="space-y-5">
@@ -178,6 +193,14 @@ export default function DosificadorDashboard() {
                   Checklists
                 </Link>
               </Button>
+              {reportShortcuts.map((s) => (
+                <Button key={s.href} size="lg" variant="outline" className="min-h-[48px] gap-2" asChild>
+                  <Link href={s.href}>
+                    <BarChart3 className="h-5 w-5" />
+                    {s.label}
+                  </Link>
+                </Button>
+              ))}
               <Button
                 type="button"
                 size="lg"

--- a/app/api/reports/asset-diesel-efficiency/route.ts
+++ b/app/api/reports/asset-diesel-efficiency/route.ts
@@ -5,6 +5,7 @@ import { computeAssetDieselEfficiencyMonths } from '@/lib/reports/compute-asset-
 import { dieselEfficiencyReportMonths } from '@/lib/reports/month-utils'
 import {
   canRecomputeDieselEfficiency,
+  requireEficienciaDieselApiAccess,
   requireReportsApiAccess,
 } from '@/lib/reports/report-api-auth'
 import type { Database } from '@/types/supabase-types'
@@ -18,7 +19,7 @@ type PostBody = {
 
 export async function GET(req: NextRequest) {
   try {
-    const auth = await requireReportsApiAccess()
+    const auth = await requireEficienciaDieselApiAccess()
     if (!auth.ok) return auth.response
     const supabase = auth.supabase
 

--- a/app/diesel/page.tsx
+++ b/app/diesel/page.tsx
@@ -16,6 +16,7 @@ import {
   type DieselHubEmptyReason,
 } from "@/lib/diesel/load-organizational-scope"
 import { useAuthZustand } from "@/hooks/use-auth-zustand"
+import { canAccessEficienciaDieselReport } from "@/lib/reports/reports-catalog"
 import {
   Fuel,
   TruckIcon,
@@ -72,6 +73,7 @@ export default function DieselDashboardPage() {
   const [warehouseLoadError, setWarehouseLoadError] = useState<string | null>(null)
 
   const showCreateWarehouse = canCreateFuelWarehouse(profile?.role)
+  const showEficienciaDieselReport = canAccessEficienciaDieselReport(profile ?? {})
 
   const supabase = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -340,6 +342,17 @@ export default function DieselDashboardPage() {
             <ClipboardList className="h-5 w-5 mr-2" />
             Validación horómetro
           </Button>
+
+          {showEficienciaDieselReport && (
+            <Button
+              onClick={() => router.push('/reportes/eficiencia-diesel')}
+              className="h-16"
+              variant="outline"
+            >
+              <Fuel className="h-5 w-5 mr-2" />
+              Eficiencia diésel
+            </Button>
+          )}
         </div>
       </div>
 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -306,6 +306,17 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                           Historial de Diesel
                         </Link>
                       </Button>
+                      <Button
+                        variant={isPathActive("/reportes/eficiencia-diesel") ? "secondary" : "ghost"}
+                        className={cn("w-full justify-start pl-8", navItemClasses)}
+                        asChild
+                        onClick={handleLinkClick}
+                      >
+                        <Link href="/reportes/eficiencia-diesel">
+                          <BarChart3 className="mr-2 h-4 w-4" />
+                          Eficiencia diésel
+                        </Link>
+                      </Button>
                     </>
                   )}
                 </CollapsibleContent>
@@ -1448,6 +1459,13 @@ export function CollapsedSidebar({ className, onLinkClick }: SidebarProps) {
               label: "Historial de Diesel",
               href: "/diesel/historial",
               active: isPathActive("/diesel/historial"),
+            },
+            {
+              id: "eficiencia-diesel",
+              icon: BarChart3,
+              label: "Eficiencia diésel",
+              href: "/reportes/eficiencia-diesel",
+              active: isPathActive("/reportes/eficiencia-diesel"),
             },
           ]
         : []),

--- a/lib/auth/role-permissions.ts
+++ b/lib/auth/role-permissions.ts
@@ -630,6 +630,13 @@ export function canAccessRoute(userRole: string, pathname: string): boolean {
   if (pathname === '/credencial' || pathname.startsWith('/credencial/')) {
     return true
   }
+  if (
+    userRole === 'DOSIFICADOR' &&
+    (pathname === '/reportes/eficiencia-diesel' ||
+      pathname.startsWith('/reportes/eficiencia-diesel/'))
+  ) {
+    return true
+  }
 
   for (const [prefix, module] of ROUTE_MODULE_RULES) {
     if (pathMatchesRoute(pathname, prefix)) {

--- a/lib/reports/executive-dashboard-shortcuts.ts
+++ b/lib/reports/executive-dashboard-shortcuts.ts
@@ -27,6 +27,7 @@ const BASE_BY_ROLE: Partial<Record<LegacyDbRole, DashboardReportShortcut[]>> = {
     { label: 'Reporte gerencial', href: '/reportes/gerencial' },
     { label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' },
   ],
+  DOSIFICADOR: [{ label: 'Eficiencia diésel', href: '/reportes/eficiencia-diesel' }],
   AREA_ADMINISTRATIVA: [
     { label: 'Centro de mando', href: '/reportes/gerencial/analisis-costos' },
     { label: 'Reporte gerencial', href: '/reportes/gerencial' },

--- a/lib/reports/report-api-auth.ts
+++ b/lib/reports/report-api-auth.ts
@@ -4,6 +4,7 @@ import { effectiveRoleForPermissions } from '@/lib/auth/role-model'
 import { loadActorContext, type ActorContext } from '@/lib/auth/server-authorization'
 import { hasModuleAccess } from '@/lib/auth/role-permissions'
 import {
+  canAccessEficienciaDieselReport,
   canAccessIngresosGastosReport,
   canAccessManualCostsReport,
   canAccessReportsModule,
@@ -40,6 +41,41 @@ export async function requireReportsApiAccess(): Promise<ReportsApiAuthResult> {
       ok: false,
       response: NextResponse.json(
         { error: 'Sin permiso para módulo de reportes' },
+        { status: 403 }
+      ),
+    }
+  }
+
+  return { ok: true, actor, supabase }
+}
+
+export async function requireEficienciaDieselApiAccess(): Promise<ReportsApiAuthResult> {
+  const supabase = await createServerSupabase()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'No autenticado' }, { status: 401 }),
+    }
+  }
+
+  const actor = await loadActorContext(supabase, user.id)
+  if (!actor) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Perfil no encontrado' }, { status: 403 }),
+    }
+  }
+
+  if (!canAccessEficienciaDieselReport(actor.profile)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Sin permiso para el reporte de eficiencia diésel' },
         { status: 403 }
       ),
     }

--- a/lib/reports/reports-catalog.ts
+++ b/lib/reports/reports-catalog.ts
@@ -94,6 +94,9 @@ const INGRESOS_GASTOS_ROLES = new Set<LegacyDbRole | FutureBusinessRole>([
 ])
 
 export const INGRESOS_GASTOS_PATH_PREFIX = '/reportes/gerencial/ingresos-gastos'
+export const EFICIENCIA_DIESEL_PATH_PREFIX = '/reportes/eficiencia-diesel'
+
+const EFICIENCIA_DIESEL_ROLES = new Set<LegacyDbRole | FutureBusinessRole>(['DOSIFICADOR'])
 
 function roleInSet(
   profile: { role?: string | null; business_role?: string | null },
@@ -122,6 +125,22 @@ export function canAccessReportsModule(profile: {
   return key ? hasModuleAccess(key, 'reports') : false
 }
 
+/** Eficiencia diésel — full reports module or Dosificador (plant-scoped via RLS). */
+export function canAccessEficienciaDieselReport(profile: {
+  role?: string | null
+  business_role?: string | null
+}): boolean {
+  if (roleInSet(profile, EFICIENCIA_DIESEL_ROLES)) return true
+  return canAccessReportsModule(profile)
+}
+
+function isEficienciaDieselPath(pathname: string): boolean {
+  return (
+    pathname === EFICIENCIA_DIESEL_PATH_PREFIX ||
+    pathname.startsWith(`${EFICIENCIA_DIESEL_PATH_PREFIX}/`)
+  )
+}
+
 export function canAccessIngresosGastosReport(profile: {
   role?: string | null
   business_role?: string | null
@@ -145,7 +164,10 @@ export function filterReportsForProfile(profile: {
   role?: string | null
   business_role?: string | null
 }): ReportCatalogEntry[] {
-  if (!canAccessReportsModule(profile)) return []
+  if (!canAccessReportsModule(profile)) {
+    if (!canAccessEficienciaDieselReport(profile)) return []
+    return REPORT_CATALOG.filter((entry) => entry.id === 'eficiencia-diesel')
+  }
 
   return REPORT_CATALOG.filter((entry) => {
     if (entry.id === 'ingresos-gastos') return canAccessIngresosGastosReport(profile)
@@ -180,6 +202,9 @@ export function canAccessReportPath(
   pathname: string
 ): boolean {
   if (!pathname.startsWith('/reportes')) return true
+  if (isEficienciaDieselPath(pathname)) {
+    return canAccessEficienciaDieselReport(profile)
+  }
   if (!canAccessReportsModule(profile)) return false
   if (
     pathname === INGRESOS_GASTOS_PATH_PREFIX ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -5390,9 +5390,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5407,9 +5404,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dosificadores can now open the **Eficiencia diésel** report (`/reportes/eficiencia-diesel`) without gaining access to the full reports module. Quick-access entry points were added on the dosificador dashboard, the diesel hub, and sidebar navigation.

## Changes

- **Permission gate** (`canAccessEficienciaDieselReport`): grants DOSIFICADOR access only to the eficiencia diésel route and API (GET). Other report paths remain blocked.
- **Route guards**: `canAccessRoute` and `canAccessReportPath` updated so dosificadores are not redirected away from the report.
- **API**: `asset-diesel-efficiency` GET uses `requireEficienciaDieselApiAccess`; recompute (POST) stays restricted to maintenance leadership.
- **UI quick access**:
  - Dosificador dashboard — shortcuts strip, action buttons, and module links
  - Diesel hub (`/diesel`) — new button under "Reportes y Analíticas"
  - Sidebar — "Eficiencia diésel" link in the dosificador operations section

## Security

Data remains **plant-scoped** via existing RLS on `asset_diesel_efficiency_monthly` (`profiles.plant_id` match). Dosificadores cannot access other reports or trigger recompute.

## Test plan

- [ ] Log in as DOSIFICADOR and open `/dashboard/dosificador` — verify "Eficiencia diésel" appears in shortcuts and action buttons
- [ ] From `/diesel`, open "Eficiencia diésel" and confirm the report loads with only the assigned plant's data
- [ ] Confirm `/reportes` and other report routes still deny access for DOSIFICADOR
- [ ] Confirm recompute remains unavailable for DOSIFICADOR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87651ff2-0113-41d1-adcd-1c61fea2a489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87651ff2-0113-41d1-adcd-1c61fea2a489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

