### PR TITLE
feat(agenda): Planning v2, mechanic workflow, procurement nav

### DIFF
--- a/app/(dashboard)/dashboard/mechanic/page.tsx
+++ b/app/(dashboard)/dashboard/mechanic/page.tsx
@@ -41,16 +41,30 @@ export default function MechanicDashboard() {
         icon={Wrench}
         count={0}
         label="órdenes de trabajo asignadas"
-        href="/ordenes"
-        ctaLabel="Ver mis OTs"
+        href="/ordenes/agenda/hoja"
+        ctaLabel="Mi orden del día"
       />
       <div className="flex flex-wrap gap-3">
+        <Link
+          href="/ordenes/agenda/hoja"
+          className="inline-flex items-center gap-2 rounded-lg border bg-card px-4 py-3 text-sm font-medium transition-colors hover:bg-accent"
+        >
+          <Wrench className="h-4 w-4" />
+          Orden del día
+        </Link>
+        <Link
+          href="/ordenes/agenda"
+          className="inline-flex items-center gap-2 rounded-lg border bg-card px-4 py-3 text-sm font-medium transition-colors hover:bg-accent"
+        >
+          <Wrench className="h-4 w-4" />
+          Agenda semanal
+        </Link>
         <Link
           href="/ordenes"
           className="inline-flex items-center gap-2 rounded-lg border bg-card px-4 py-3 text-sm font-medium transition-colors hover:bg-accent"
         >
           <Wrench className="h-4 w-4" />
-          Ver todas las órdenes
+          Todas las OTs
         </Link>
       </div>
     </DashboardShell>

--- a/app/api/incidents/routed/route.ts
+++ b/app/api/incidents/routed/route.ts
@@ -97,6 +97,13 @@ export async function GET(req: NextRequest) {
     const offset = Math.max(Number(searchParams.get("offset") ?? "0"), 0)
 
     const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
 
     const { data: allDepartments } = await supabase
       .from("departments")

--- a/app/api/incidents/routed/route.ts
+++ b/app/api/incidents/routed/route.ts
@@ -226,13 +226,21 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
     const body = (await req.json()) as { incident_ids?: string[] }
     const incidentIds = body.incident_ids ?? []
     if (incidentIds.length === 0) {
       return NextResponse.json({ error: "incident_ids requerido" }, { status: 400 })
     }
 
-    const supabase = await createClient()
     const results: { id: string; ok: boolean; error?: string }[] = []
 
     for (const incidentId of incidentIds) {

--- a/app/api/integrations/cotizador/orders/route.ts
+++ b/app/api/integrations/cotizador/orders/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient as createServerSupabase } from "@/lib/supabase-server"
+import { createClient } from "@supabase/supabase-js"
+import {
+  buildCotizadorPlantMaps,
+  resolveCotizadorPlantIds,
+} from "@/lib/agenda/cotizador-plant-map"
+import { flattenCotizadorOrders, type CotizadorOrderItemRow } from "@/lib/agenda/cotizador-orders"
+
+export type { CotizadorOrderItemRow }
+
+/**
+ * GET /api/integrations/cotizador/orders?from=&to=&plantIds=
+ * Planning orders from Cotizador (created/validated) for a delivery date range.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const supabase = await createServerSupabase()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(req.url)
+    const from = searchParams.get("from")
+    const to = searchParams.get("to")
+    const plantIdsParam = searchParams.get("plantIds")
+    const includePump = searchParams.get("include_pump") === "true"
+
+    if (!from || !to) {
+      return NextResponse.json({ error: "from y to son requeridos" }, { status: 400 })
+    }
+
+    const url = process.env.COTIZADOR_SUPABASE_URL
+    const key = process.env.COTIZADOR_SUPABASE_SERVICE_ROLE_KEY
+    if (!url || !key) {
+      return NextResponse.json({ orders: [], configured: false })
+    }
+
+    const plantMaps = await buildCotizadorPlantMaps(supabase)
+    const cotizadorPlantIds = resolveCotizadorPlantIds(plantIdsParam, plantMaps)
+
+    const cotizador = createClient(url, key, { auth: { persistSession: false } })
+
+    let query = cotizador
+      .from("orders")
+      .select(
+        `
+        id,
+        order_number,
+        delivery_date,
+        delivery_time,
+        construction_site,
+        plant_id,
+        order_status,
+        plant:plants(id, name),
+        client:clients(name),
+        order_items(product_type, volume, concrete_volume_delivered)
+      `,
+      )
+      .in("order_status", ["created", "validated"])
+      .gte("delivery_date", from)
+      .lte("delivery_date", to)
+      .order("delivery_date", { ascending: true })
+      .order("delivery_time", { ascending: true })
+
+    if (cotizadorPlantIds?.length) {
+      query = query.in("plant_id", cotizadorPlantIds)
+    }
+
+    const { data, error } = await query
+
+    if (error) {
+      console.error("[cotizador/orders]", error)
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    const orders = flattenCotizadorOrders(data ?? [], { includePumpLines: includePump })
+
+    return NextResponse.json({
+      configured: true,
+      orders,
+      plant_mapping: Object.fromEntries(plantMaps.cotizadorToMaintenance),
+    })
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Error interno"
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/app/api/integrations/cotizador/orders/route.ts
+++ b/app/api/integrations/cotizador/orders/route.ts
@@ -6,6 +6,7 @@ import {
   resolveCotizadorPlantIds,
 } from "@/lib/agenda/cotizador-plant-map"
 import { flattenCotizadorOrders, type CotizadorOrderItemRow } from "@/lib/agenda/cotizador-orders"
+import { canAccessAgendaIntegrations, canViewCotizadorPlantMapping } from "@/lib/agenda/agenda-auth"
 
 export type { CotizadorOrderItemRow }
 
@@ -22,6 +23,20 @@ export async function GET(req: NextRequest) {
     } = await supabase.auth.getUser()
     if (authError || !user) {
       return NextResponse.json({ error: "No autorizado" }, { status: 401 })
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("role, is_active")
+      .eq("id", user.id)
+      .single()
+
+    if (profileError || !profile || !profile.is_active) {
+      return NextResponse.json({ error: "Perfil no encontrado o inactivo" }, { status: 403 })
+    }
+
+    if (!canAccessAgendaIntegrations(profile.role)) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 403 })
     }
 
     const { searchParams } = new URL(req.url)
@@ -83,7 +98,9 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({
       configured: true,
       orders,
-      plant_mapping: Object.fromEntries(plantMaps.cotizadorToMaintenance),
+      ...(canViewCotizadorPlantMapping(profile.role)
+        ? { plant_mapping: Object.fromEntries(plantMaps.cotizadorToMaintenance) }
+        : {}),
     })
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Error interno"

--- a/app/api/integrations/cotizador/remisiones/route.ts
+++ b/app/api/integrations/cotizador/remisiones/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient as createServerSupabase } from '@/lib/supabase-server'
 import { createClient } from '@supabase/supabase-js'
+import { canAccessAgendaIntegrations } from '@/lib/agenda/agenda-auth'
 
 export type RemisionRow = {
   remision_number: string
@@ -23,13 +24,34 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
     }
 
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('role, is_active')
+      .eq('id', user.id)
+      .single()
+
+    if (profileError || !profile || !profile.is_active) {
+      return NextResponse.json({ error: 'Perfil no encontrado o inactivo' }, { status: 403 })
+    }
+
+    if (!canAccessAgendaIntegrations(profile.role)) {
+      return NextResponse.json({ error: 'No autorizado' }, { status: 403 })
+    }
+
     const { searchParams } = new URL(req.url)
     const assetId = searchParams.get('assetId')
+    const assetIdsParam = searchParams.get('assetIds')
     const from = searchParams.get('from')
     const to = searchParams.get('to')
 
-    if (!assetId || !from || !to) {
-      return NextResponse.json({ error: 'assetId, from y to son requeridos' }, { status: 400 })
+    const assetIds = assetIdsParam
+      ? [...new Set(assetIdsParam.split(',').map((value) => value.trim()).filter(Boolean))]
+      : assetId
+        ? [assetId]
+        : []
+
+    if (assetIds.length === 0 || !from || !to) {
+      return NextResponse.json({ error: 'assetId o assetIds, from y to son requeridos' }, { status: 400 })
     }
 
     const url = process.env.COTIZADOR_SUPABASE_URL
@@ -42,8 +64,8 @@ export async function GET(req: NextRequest) {
 
     const { data, error } = await cotizador
       .from('remisiones')
-      .select('remision_number, fecha, hora_carga, volumen_fabricado, cancelled_reason')
-      .eq('unidad', assetId)
+      .select('remision_number, fecha, hora_carga, volumen_fabricado, cancelled_reason, unidad')
+      .in('unidad', assetIds)
       .gte('fecha', from)
       .lte('fecha', to)
       .order('fecha', { ascending: true })
@@ -54,7 +76,27 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 })
     }
 
-    return NextResponse.json({ remisiones: (data ?? []) as RemisionRow[] })
+    const remisionesByAsset: Record<string, RemisionRow[]> = {}
+    for (const asset of assetIds) {
+      remisionesByAsset[asset] = []
+    }
+
+    for (const row of data ?? []) {
+      const unit = (row as { unidad?: string }).unidad
+      if (!unit) continue
+      if (!remisionesByAsset[unit]) remisionesByAsset[unit] = []
+      remisionesByAsset[unit].push({
+        remision_number: row.remision_number,
+        fecha: row.fecha,
+        hora_carga: row.hora_carga,
+        volumen_fabricado: row.volumen_fabricado,
+        cancelled_reason: row.cancelled_reason,
+      })
+    }
+
+    const remisiones = assetIds.length === 1 ? remisionesByAsset[assetIds[0]!] ?? [] : []
+
+    return NextResponse.json({ remisiones, remisiones_by_asset: remisionesByAsset })
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Error interno'
     return NextResponse.json({ error: msg }, { status: 500 })

--- a/app/api/work-orders/[id]/schedule/route.ts
+++ b/app/api/work-orders/[id]/schedule/route.ts
@@ -23,14 +23,21 @@ export async function PATCH(
     }
 
     const body = await request.json()
-    const { planned_date, assigned_to } = body as {
+    const { planned_date, assigned_to, status, priority } = body as {
       planned_date?: string | null
       assigned_to?: string | null
+      status?: string | null
+      priority?: string | null
     }
 
-    if (planned_date === undefined && assigned_to === undefined) {
+    if (
+      planned_date === undefined &&
+      assigned_to === undefined &&
+      status === undefined &&
+      priority === undefined
+    ) {
       return NextResponse.json(
-        { error: "Se requiere planned_date y/o assigned_to" },
+        { error: "Se requiere al menos un campo para actualizar" },
         { status: 400 },
       )
     }
@@ -38,6 +45,7 @@ export async function PATCH(
     const updatePayload: Record<string, unknown> = {}
     if (planned_date !== undefined) updatePayload.planned_date = planned_date
     if (assigned_to !== undefined) updatePayload.assigned_to = assigned_to
+    if (priority !== undefined) updatePayload.priority = priority
 
     const { data: existing, error: fetchError } = await supabase
       .from("work_orders")
@@ -52,7 +60,9 @@ export async function PATCH(
     const nextPlanned = planned_date !== undefined ? planned_date : existing.planned_date
     const nextAssigned = assigned_to !== undefined ? assigned_to : existing.assigned_to
 
-    if (nextPlanned && nextAssigned && existing.status === "Pendiente") {
+    if (status !== undefined && status !== null) {
+      updatePayload.status = status
+    } else if (nextPlanned && nextAssigned && existing.status === "Pendiente") {
       updatePayload.status = "Programada"
     }
 

--- a/app/api/work-orders/[id]/schedule/route.ts
+++ b/app/api/work-orders/[id]/schedule/route.ts
@@ -5,6 +5,9 @@
 
 import { createClient } from "@/lib/supabase-server"
 import { NextResponse } from "next/server"
+import { AGENDA_ACTIVE_STATUSES } from "@/lib/agenda/agenda-utils"
+
+const SCHEDULABLE_STATUSES = new Set<string>(AGENDA_ACTIVE_STATUSES)
 
 export async function PATCH(
   request: Request,
@@ -61,6 +64,9 @@ export async function PATCH(
     const nextAssigned = assigned_to !== undefined ? assigned_to : existing.assigned_to
 
     if (status !== undefined && status !== null) {
+      if (!SCHEDULABLE_STATUSES.has(status)) {
+        return NextResponse.json({ error: "Estado no permitido para programación" }, { status: 400 })
+      }
       updatePayload.status = status
     } else if (nextPlanned && nextAssigned && existing.status === "Pendiente") {
       updatePayload.status = "Programada"

--- a/app/api/work-orders/[id]/status/route.ts
+++ b/app/api/work-orders/[id]/status/route.ts
@@ -1,0 +1,70 @@
+/**
+ * Quick status update for mechanics (start / waiting parts) without full WO form.
+ */
+
+import { createClient } from "@/lib/supabase-server"
+import { WorkOrderStatus } from "@/types"
+import { NextResponse } from "next/server"
+
+const ALLOWED_STATUSES = new Set([
+  WorkOrderStatus.Pending,
+  WorkOrderStatus.Programmed,
+  WorkOrderStatus.WaitingParts,
+  "En ejecución",
+  "En Progreso",
+])
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params
+    const supabase = await createClient()
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const { status } = body as { status?: string }
+
+    if (!status || !ALLOWED_STATUSES.has(status)) {
+      return NextResponse.json({ error: "Estado no válido" }, { status: 400 })
+    }
+
+    const { data: existing, error: fetchError } = await supabase
+      .from("work_orders")
+      .select("id, status")
+      .eq("id", id)
+      .single()
+
+    if (fetchError || !existing) {
+      return NextResponse.json({ error: "Orden de trabajo no encontrada" }, { status: 404 })
+    }
+
+    if (existing.status === WorkOrderStatus.Completed) {
+      return NextResponse.json({ error: "La orden ya está completada" }, { status: 400 })
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from("work_orders")
+      .update({ status, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .select("id, order_id, status")
+      .single()
+
+    if (updateError) {
+      return NextResponse.json({ error: updateError.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, work_order: updated })
+  } catch (error) {
+    console.error("Error updating work order status:", error)
+    return NextResponse.json({ error: "Error interno del servidor" }, { status: 500 })
+  }
+}

--- a/app/api/work-orders/[id]/status/route.ts
+++ b/app/api/work-orders/[id]/status/route.ts
@@ -5,6 +5,7 @@
 import { createClient } from "@/lib/supabase-server"
 import { WorkOrderStatus } from "@/types"
 import { NextResponse } from "next/server"
+import { canQuickUpdateWorkOrderStatus } from "@/lib/agenda/agenda-auth"
 
 const ALLOWED_STATUSES = new Set([
   WorkOrderStatus.Pending,
@@ -30,6 +31,16 @@ export async function PATCH(
       return NextResponse.json({ error: "No autorizado" }, { status: 401 })
     }
 
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select("role, is_active")
+      .eq("id", user.id)
+      .single()
+
+    if (profileError || !profile || !profile.is_active) {
+      return NextResponse.json({ error: "Perfil no encontrado o inactivo" }, { status: 403 })
+    }
+
     const body = await request.json()
     const { status } = body as { status?: string }
 
@@ -39,12 +50,18 @@ export async function PATCH(
 
     const { data: existing, error: fetchError } = await supabase
       .from("work_orders")
-      .select("id, status")
+      .select("id, status, assigned_to")
       .eq("id", id)
       .single()
 
     if (fetchError || !existing) {
       return NextResponse.json({ error: "Orden de trabajo no encontrada" }, { status: 404 })
+    }
+
+    if (
+      !canQuickUpdateWorkOrderStatus(profile.role, user.id, existing.assigned_to as string | null)
+    ) {
+      return NextResponse.json({ error: "No autorizado para actualizar esta orden" }, { status: 403 })
     }
 
     if (existing.status === WorkOrderStatus.Completed) {

--- a/app/api/work-orders/agenda/daily-kit/route.ts
+++ b/app/api/work-orders/agenda/daily-kit/route.ts
@@ -10,9 +10,10 @@ import {
   recomputeKitSufficiency,
   type ConsolidatedKitLine,
 } from "@/lib/agenda/aggregate-daily-kit"
+import { AGENDA_ACTIVE_STATUSES } from "@/lib/agenda/agenda-utils"
 import { StockService, type PartAvailability } from "@/lib/services/stock-service"
 
-const ACTIVE_STATUSES = ["Pendiente", "Programada", "Esperando repuestos"]
+const ACTIVE_STATUSES = [...AGENDA_ACTIVE_STATUSES]
 
 export type DailyKitWorkOrderParts = {
   work_order_id: string
@@ -77,15 +78,19 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 })
     }
 
-    const allLines = (workOrders ?? []).flatMap((wo) =>
-      extractPartsFromWorkOrder({
-        id: wo.id,
-        order_id: wo.order_id,
-        asset_id: wo.asset_id,
-        required_parts: wo.required_parts,
-        required_tasks: wo.required_tasks,
-      }),
-    )
+    const allLines = (workOrders ?? []).flatMap((wo) => {
+      const asset = wo.asset as { plant_id?: string | null } | null
+      return extractPartsFromWorkOrder(
+        {
+          id: wo.id,
+          order_id: wo.order_id,
+          asset_id: wo.asset_id,
+          required_parts: wo.required_parts,
+          required_tasks: wo.required_tasks,
+        },
+        asset?.plant_id,
+      )
+    })
 
     const partsByPlant = new Map<string, Map<string, number>>()
     for (const wo of workOrders ?? []) {
@@ -95,13 +100,16 @@ export async function GET(request: NextRequest) {
       const plantId = asset?.plant_id
       if (!plantId) continue
 
-      const woLines = extractPartsFromWorkOrder({
-        id: wo.id,
-        order_id: wo.order_id,
-        asset_id: wo.asset_id,
-        required_parts: wo.required_parts,
-        required_tasks: wo.required_tasks,
-      })
+      const woLines = extractPartsFromWorkOrder(
+        {
+          id: wo.id,
+          order_id: wo.order_id,
+          asset_id: wo.asset_id,
+          required_parts: wo.required_parts,
+          required_tasks: wo.required_tasks,
+        },
+        plantId,
+      )
 
       if (!partsByPlant.has(plantId)) partsByPlant.set(plantId, new Map())
       const plantParts = partsByPlant.get(plantId)!
@@ -120,10 +128,7 @@ export async function GET(request: NextRequest) {
       }))
       const availabilities = await StockService.checkMultiplePartsAvailability(parts, plantId)
       for (const row of availabilities) {
-        const existing = availabilityByPartId.get(row.part_id)
-        if (!existing || row.total_available > existing.total_available) {
-          availabilityByPartId.set(row.part_id, row)
-        }
+        availabilityByPartId.set(`${plantId}:${row.part_id}`, row)
       }
     }
 
@@ -135,13 +140,16 @@ export async function GET(request: NextRequest) {
         name?: string | null
         plant_id?: string | null
       } | null
-      const woLines = extractPartsFromWorkOrder({
-        id: wo.id,
-        order_id: wo.order_id,
-        asset_id: wo.asset_id,
-        required_parts: wo.required_parts,
-        required_tasks: wo.required_tasks,
-      })
+      const woLines = extractPartsFromWorkOrder(
+        {
+          id: wo.id,
+          order_id: wo.order_id,
+          asset_id: wo.asset_id,
+          required_parts: wo.required_parts,
+          required_tasks: wo.required_tasks,
+        },
+        asset?.plant_id,
+      )
       const woKit = consolidateKitLines(woLines, availabilityByPartId)
 
       return {

--- a/app/api/work-orders/agenda/daily-kit/route.ts
+++ b/app/api/work-orders/agenda/daily-kit/route.ts
@@ -1,0 +1,193 @@
+/**
+ * Daily insumos kit — parts required for scheduled work on a given date.
+ */
+
+import { createClient } from "@/lib/supabase-server"
+import { NextRequest, NextResponse } from "next/server"
+import {
+  consolidateKitLines,
+  extractPartsFromWorkOrder,
+  recomputeKitSufficiency,
+  type ConsolidatedKitLine,
+} from "@/lib/agenda/aggregate-daily-kit"
+import { StockService, type PartAvailability } from "@/lib/services/stock-service"
+
+const ACTIVE_STATUSES = ["Pendiente", "Programada", "Esperando repuestos"]
+
+export type DailyKitWorkOrderParts = {
+  work_order_id: string
+  order_id: string
+  asset_id: string | null
+  asset_code: string | null
+  asset_name: string | null
+  plant_id: string | null
+  parts: Array<{
+    part_id: string | null
+    part_number: string
+    name: string
+    quantity: number
+    total_available: number | null
+    sufficient: boolean | null
+  }>
+}
+
+/**
+ * GET /api/work-orders/agenda/daily-kit?date=YYYY-MM-DD&technicianId=
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const date = searchParams.get("date")
+    const technicianId = searchParams.get("technicianId")
+
+    if (!date) {
+      return NextResponse.json({ error: "date es requerido (yyyy-MM-dd)" }, { status: 400 })
+    }
+
+    let woQuery = supabase
+      .from("work_orders")
+      .select(
+        `
+        id,
+        order_id,
+        asset_id,
+        required_parts,
+        required_tasks,
+        asset:assets(id, asset_id, name, plant_id)
+      `,
+      )
+      .eq("planned_date", date)
+      .in("status", ACTIVE_STATUSES)
+
+    if (technicianId) {
+      woQuery = woQuery.eq("assigned_to", technicianId)
+    }
+
+    const { data: workOrders, error } = await woQuery
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    const allLines = (workOrders ?? []).flatMap((wo) =>
+      extractPartsFromWorkOrder({
+        id: wo.id,
+        order_id: wo.order_id,
+        asset_id: wo.asset_id,
+        required_parts: wo.required_parts,
+        required_tasks: wo.required_tasks,
+      }),
+    )
+
+    const partsByPlant = new Map<string, Map<string, number>>()
+    for (const wo of workOrders ?? []) {
+      const asset = wo.asset as {
+        plant_id?: string | null
+      } | null
+      const plantId = asset?.plant_id
+      if (!plantId) continue
+
+      const woLines = extractPartsFromWorkOrder({
+        id: wo.id,
+        order_id: wo.order_id,
+        asset_id: wo.asset_id,
+        required_parts: wo.required_parts,
+        required_tasks: wo.required_tasks,
+      })
+
+      if (!partsByPlant.has(plantId)) partsByPlant.set(plantId, new Map())
+      const plantParts = partsByPlant.get(plantId)!
+      for (const line of woLines) {
+        if (!line.part_id) continue
+        const prev = plantParts.get(line.part_id) ?? 0
+        plantParts.set(line.part_id, prev + Number(line.quantity ?? 0))
+      }
+    }
+
+    const availabilityByPartId = new Map<string, PartAvailability>()
+    for (const [plantId, partQtyMap] of partsByPlant) {
+      const parts = [...partQtyMap.entries()].map(([part_id, quantity]) => ({
+        part_id,
+        quantity,
+      }))
+      const availabilities = await StockService.checkMultiplePartsAvailability(parts, plantId)
+      for (const row of availabilities) {
+        const existing = availabilityByPartId.get(row.part_id)
+        if (!existing || row.total_available > existing.total_available) {
+          availabilityByPartId.set(row.part_id, row)
+        }
+      }
+    }
+
+    const kit = recomputeKitSufficiency(consolidateKitLines(allLines, availabilityByPartId))
+
+    const byWorkOrder: DailyKitWorkOrderParts[] = (workOrders ?? []).map((wo) => {
+      const asset = wo.asset as {
+        asset_id?: string | null
+        name?: string | null
+        plant_id?: string | null
+      } | null
+      const woLines = extractPartsFromWorkOrder({
+        id: wo.id,
+        order_id: wo.order_id,
+        asset_id: wo.asset_id,
+        required_parts: wo.required_parts,
+        required_tasks: wo.required_tasks,
+      })
+      const woKit = consolidateKitLines(woLines, availabilityByPartId)
+
+      return {
+        work_order_id: wo.id,
+        order_id: wo.order_id,
+        asset_id: wo.asset_id,
+        asset_code: asset?.asset_id ?? null,
+        asset_name: asset?.name ?? null,
+        plant_id: asset?.plant_id ?? null,
+        parts: woKit.map((p) => ({
+          part_id: p.part_id,
+          part_number: p.part_number,
+          name: p.name,
+          quantity: p.required_quantity,
+          total_available: p.total_available,
+          sufficient: p.sufficient,
+        })),
+      }
+    })
+
+    const plantIds = [
+      ...new Set(
+        (workOrders ?? [])
+          .map((wo) => (wo.asset as { plant_id?: string | null } | null)?.plant_id)
+          .filter(Boolean),
+      ),
+    ] as string[]
+
+    const summary = {
+      total_parts: kit.length,
+      insufficient: kit.filter((k) => k.sufficient === false).length,
+      unknown: kit.filter((k) => k.sufficient == null).length,
+      sufficient: kit.filter((k) => k.sufficient === true).length,
+    }
+
+    return NextResponse.json({
+      date,
+      technician_id: technicianId,
+      work_order_count: workOrders?.length ?? 0,
+      plant_ids: plantIds,
+      kit: kit satisfies ConsolidatedKitLine[],
+      by_work_order: byWorkOrder,
+      summary,
+    })
+  } catch (error) {
+    console.error("Error in daily-kit API:", error)
+    return NextResponse.json({ error: "Error interno del servidor" }, { status: 500 })
+  }
+}

--- a/app/api/work-orders/agenda/route.ts
+++ b/app/api/work-orders/agenda/route.ts
@@ -4,9 +4,9 @@
 
 import { createClient } from "@/lib/supabase-server"
 import { NextRequest, NextResponse } from "next/server"
-import { inferWorkOrderOrigin } from "@/lib/agenda/agenda-utils"
+import { AGENDA_ACTIVE_STATUSES, inferWorkOrderOrigin } from "@/lib/agenda/agenda-utils"
 
-const ACTIVE_STATUSES = ["Pendiente", "Programada", "Esperando repuestos"]
+const ACTIVE_STATUSES = [...AGENDA_ACTIVE_STATUSES]
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,6 +16,26 @@ export async function GET(request: NextRequest) {
     const to = searchParams.get("to")
     const assignedTo = searchParams.get("assigned_to")
     const includeUnscheduled = searchParams.get("include_unscheduled") === "true"
+    const techniciansOnly = searchParams.get("technicians_only") === "true"
+
+    if (techniciansOnly) {
+      const { data: techs, error: techsError } = await supabase
+        .from("profiles")
+        .select("id, nombre, apellido")
+        .eq("is_active", true)
+        .limit(500)
+
+      if (techsError) {
+        return NextResponse.json({ error: techsError.message }, { status: 500 })
+      }
+
+      return NextResponse.json({
+        technicians: (techs ?? []).map((t) => ({
+          id: t.id,
+          name: [t.nombre, t.apellido].filter(Boolean).join(" ") || "Sin nombre",
+        })),
+      })
+    }
 
     if (!from || !to) {
       return NextResponse.json(

--- a/app/compras/[id]/page.tsx
+++ b/app/compras/[id]/page.tsx
@@ -23,6 +23,7 @@ import { TypeBadge } from "@/components/purchase-orders/shared/TypeBadge"
 import { ReceiptDisplaySection } from "@/components/purchase-orders/ReceiptDisplaySection"
 import { PoSupplierInvoiceSection } from "@/components/purchase-orders/PoSupplierInvoiceSection"
 import { PoLifecycleStrip } from "@/components/compras/procurement/ProcurementDashboardTab"
+import { PoProcurementNavCard } from "@/components/compras/procurement/PoProcurementNavCard"
 import { suggestExpenseCategory } from "@/lib/ap/po-invoice-utils"
 import { PurchaseOrderDetailsRouter } from "@/components/purchase-orders/purchase-order-details-router"
 import { loadActorContext } from "@/lib/auth/server-authorization"
@@ -507,17 +508,21 @@ async function PurchaseOrderDetailsContent({ id }: { id: string }) {
 
           {/* Receipts / Comprobantes card */}
           {showReceiptsCard && (
-            <ReceiptDisplaySection purchaseOrderId={order.id} poType={order.po_type} />
+            <div id="po-comprobantes" className="scroll-mt-24">
+              <ReceiptDisplaySection purchaseOrderId={order.id} poType={order.po_type} />
+            </div>
           )}
 
           {/* Fiscal supplier invoice */}
           {showReceiptsCard && (
-            <PoSupplierInvoiceSection
+            <div id="po-factura-cfdi" className="scroll-mt-24">
+              <PoSupplierInvoiceSection
               purchaseOrderId={order.id}
               canRegister={canRegisterInvoice}
               defaultExpenseCategory={defaultExpenseCategory}
               poPreTaxAmount={Number(order.actual_amount) > 0 ? Number(order.actual_amount) : Number(order.approval_amount) > 0 ? Number(order.approval_amount) : Number(order.total_amount ?? 0)}
             />
+            </div>
           )}
         </div>
 
@@ -538,6 +543,12 @@ async function PurchaseOrderDetailsContent({ id }: { id: string }) {
             /* Legacy PO fallback */
             <LegacyActionCard order={order} />
           )}
+
+          <PoProcurementNavCard
+            purchaseOrderId={order.id}
+            orderIdDisplay={order.order_id}
+            showPostApproval={!!showReceiptsCard}
+          />
 
           {/* Work order relationship */}
           <Card className="rounded-2xl border border-border/60">

--- a/app/compras/comprobantes/page.tsx
+++ b/app/compras/comprobantes/page.tsx
@@ -7,6 +7,7 @@ import { FileText, Receipt, ExternalLink, Download, Eye } from "lucide-react"
 import Link from "next/link"
 import { format } from "date-fns"
 import { es } from "date-fns/locale"
+import { use } from "react"
 
 export const metadata: Metadata = {
   title: "Comprobantes | Sistema de Gestión de Mantenimiento",
@@ -87,7 +88,7 @@ function getTypeBadge(poType: string | null) {
   );
 }
 
-async function ComprobantesListContent() {
+async function ComprobantesListContent({ poId }: { poId?: string }) {
   const supabase = await createClient();
   
   // Get all purchase order receipts with order details
@@ -147,8 +148,22 @@ async function ComprobantesListContent() {
     index === self.findIndex(o => o.receipt_id === order.receipt_id)
   );
 
+  const filteredReceipts = poId
+    ? ordersWithReceipts.filter((order) => order.id === poId)
+    : ordersWithReceipts;
+
   return (
     <div className="container mx-auto py-8 space-y-6">
+      {poId && (
+        <Card className="border-sky-200 bg-sky-50/50">
+          <CardContent className="p-4 text-sm text-sky-900">
+            Filtrado por una orden de compra.{" "}
+            <Link href="/compras/comprobantes" className="underline font-medium">
+              Ver todos los comprobantes
+            </Link>
+          </CardContent>
+        </Card>
+      )}
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
@@ -159,13 +174,13 @@ async function ComprobantesListContent() {
         </div>
         <Badge variant="outline" className="bg-blue-50">
           <Receipt className="h-4 w-4 mr-1" />
-          {ordersWithReceipts.length} comprobantes
+          {filteredReceipts.length} comprobantes
         </Badge>
       </div>
 
       {/* Receipts List */}
       <div className="space-y-4">
-        {ordersWithReceipts.map((order) => (
+        {filteredReceipts.map((order) => (
           <Card key={order.receipt_id} className="hover:shadow-md transition-shadow">
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
@@ -255,7 +270,7 @@ async function ComprobantesListContent() {
           </Card>
         ))}
 
-        {ordersWithReceipts.length === 0 && (
+        {filteredReceipts.length === 0 && (
           <Card>
             <CardContent className="p-12 text-center">
               <Receipt className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
@@ -271,6 +286,11 @@ async function ComprobantesListContent() {
   );
 }
 
-export default function ComprobantesList() {
-  return <ComprobantesListContent />;
+export default function ComprobantesList({
+  searchParams,
+}: {
+  searchParams: Promise<{ po?: string }>
+}) {
+  const { po } = use(searchParams)
+  return <ComprobantesListContent poId={po} />
 } 

--- a/app/compras/cuentas-por-pagar/page.tsx
+++ b/app/compras/cuentas-por-pagar/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { Suspense } from "react"
 import { DashboardHeader } from "@/components/dashboard/dashboard-header"
 import { DashboardShell } from "@/components/dashboard/dashboard-shell"
 import { AccountsPayableView } from "@/components/purchase-orders/AccountsPayableView"
@@ -15,7 +16,9 @@ export default function AccountsPayablePage() {
         heading="Cuentas por Pagar"
         text="Control y seguimiento de pagos pendientes, vencimientos y flujo de caja para órdenes de compra."
       />
-      <AccountsPayableView />
+      <Suspense fallback={<p className="text-muted-foreground">Cargando cuentas por pagar…</p>}>
+        <AccountsPayableView />
+      </Suspense>
     </DashboardShell>
   )
 } 

--- a/app/compras/page.tsx
+++ b/app/compras/page.tsx
@@ -8,7 +8,7 @@ import { useToast } from "@/hooks/use-toast"
 import { DashboardHeader } from "@/components/dashboard/dashboard-header"
 import { DashboardShell } from "@/components/dashboard/dashboard-shell"
 import { Button } from "@/components/ui/button"
-import { Plus, Loader2, Receipt, DollarSign, FileText } from "lucide-react"
+import { Plus, Loader2, FileText } from "lucide-react"
 import { useAuthZustand } from "@/hooks/use-auth-zustand"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { ComprasMobileInfoDrawer } from "@/components/compras/ComprasMobileInfoDrawer"
@@ -195,27 +195,11 @@ function PurchaseOrdersPageContent() {
               isAdmin={!!isAdmin}
             />
           )}
-          {profile && hasCreateAccess('purchases') && (
-            <Link href="/compras/comprobantes">
-              <Button variant="outline" className="w-full sm:w-auto cursor-pointer">
-                <Receipt className="mr-2 h-4 w-4" />
-                Ver Comprobantes
-              </Button>
-            </Link>
-          )}
           {profile && (profile.role === 'GERENCIA_GENERAL' || profile.role === 'AREA_ADMINISTRATIVA') && (
             <Link href="/compras/procurement">
               <Button variant="outline" className="w-full sm:w-auto bg-sky-50 border-sky-200 text-sky-800 hover:bg-sky-100 cursor-pointer">
                 <FileText className="mr-2 h-4 w-4" />
-                Compras post-aprobación
-              </Button>
-            </Link>
-          )}
-          {profile && (profile.role === 'GERENCIA_GENERAL' || profile.role === 'AREA_ADMINISTRATIVA') && (
-            <Link href="/compras/cuentas-por-pagar">
-              <Button variant="outline" className="w-full sm:w-auto bg-orange-50 border-orange-200 text-orange-700 hover:bg-orange-100 cursor-pointer">
-                <DollarSign className="mr-2 h-4 w-4" />
-                Cuentas por Pagar
+                Post-aprobación (desde OC)
               </Button>
             </Link>
           )}

--- a/app/diesel/almacen/[id]/page.tsx
+++ b/app/diesel/almacen/[id]/page.tsx
@@ -40,6 +40,7 @@ import { MarkTransferModal } from "@/components/diesel-inventory/mark-transfer-m
 import { formatLocalDateForAccounting } from "@/lib/diesel/date-utils"
 import {
   buildCuentaLitrosGaps,
+  CUENTA_LITROS_GAP_AUDIT_FROM,
   getSignificantGaps,
   indexGapsByTransactionId,
   sumUnregisteredLiters,
@@ -165,6 +166,7 @@ export default function WarehouseDetailPage() {
     return buildCuentaLitrosGaps(transactions, {
       warehouse_id: warehouseId,
       has_cuenta_litros: true,
+      audit_from: CUENTA_LITROS_GAP_AUDIT_FROM,
     })
   }, [transactions, warehouse?.has_cuenta_litros, warehouseId])
 
@@ -702,11 +704,6 @@ export default function WarehouseDetailPage() {
   }
 
   const handleOpenEvidence = (transaction: Transaction) => {
-    const gap = gapsByTransactionId.get(transaction.id)
-    if (gap && warehouse?.has_cuenta_litros) {
-      handleOpenGap(gap)
-      return
-    }
     setEvidenceTransaction(transaction)
     setIsEvidenceModalOpen(true)
   }
@@ -1217,7 +1214,7 @@ export default function WarehouseDetailPage() {
               Salidas faltantes (cuenta litros)
             </CardTitle>
             <CardDescription>
-              Huecos detectados entre lecturas consecutivas del medidor
+              Huecos detectados entre lecturas consecutivas del medidor (desde abril 2026)
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -1527,7 +1524,7 @@ export default function WarehouseDetailPage() {
                           <TooltipTrigger asChild>
                             <Badge
                               variant="destructive"
-                              className="text-xs"
+                              className="text-xs cursor-pointer"
                               onClick={(e) => {
                                 e.stopPropagation()
                                 handleOpenGap(txGap)
@@ -1546,7 +1543,7 @@ export default function WarehouseDetailPage() {
                           <TooltipTrigger asChild>
                             <Badge
                               variant="secondary"
-                              className="text-xs"
+                              className="text-xs cursor-pointer"
                               onClick={(e) => {
                                 e.stopPropagation()
                                 handleOpenGap(txGap)

--- a/app/ordenes/page.tsx
+++ b/app/ordenes/page.tsx
@@ -18,7 +18,7 @@ export default function WorkOrdersPage() {
     <DashboardShell>
       <DashboardHeader
         heading="Órdenes de Trabajo"
-        text="Planificación, aprobación y asignación de trabajos"
+        text="Planifique cuándo atender cada trabajo: fecha, técnico y estado desde la lista o la agenda."
         id="ordenes-header"
       >
         <Button asChild>

--- a/components/agenda/agenda-day-detail-panel.tsx
+++ b/components/agenda/agenda-day-detail-panel.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { format, parseISO } from "date-fns"
+import { es } from "date-fns/locale"
+import { AlertTriangle, CheckCircle2, Package, Printer, Truck } from "lucide-react"
+import type { CotizadorOrderItemRow } from "@/lib/agenda/cotizador-orders"
+import type { ConsolidatedKitLine } from "@/lib/agenda/aggregate-daily-kit"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { cn } from "@/lib/utils"
+
+type DailyKitResponse = {
+  kit: ConsolidatedKitLine[]
+  summary: {
+    total_parts: number
+    insufficient: number
+    unknown: number
+    sufficient: number
+  }
+  plant_ids: string[]
+}
+
+type OrdersResponse = {
+  orders: CotizadorOrderItemRow[]
+  configured: boolean
+}
+
+interface AgendaDayDetailPanelProps {
+  date: string
+  technicianId?: string
+  onPrint?: () => void
+  className?: string
+}
+
+function StockBadge({ sufficient }: { sufficient: boolean | null }) {
+  if (sufficient === true) {
+    return (
+      <Badge variant="outline" className="text-green-700 border-green-300 bg-green-50">
+        <CheckCircle2 className="h-3 w-3 mr-1" />
+        OK
+      </Badge>
+    )
+  }
+  if (sufficient === false) {
+    return (
+      <Badge variant="outline" className="text-red-700 border-red-300 bg-red-50">
+        <AlertTriangle className="h-3 w-3 mr-1" />
+        Falta
+      </Badge>
+    )
+  }
+  return (
+    <Badge variant="secondary" className="text-xs">
+      Sin catálogo
+    </Badge>
+  )
+}
+
+export function AgendaDayDetailPanel({
+  date,
+  technicianId,
+  onPrint,
+  className,
+}: AgendaDayDetailPanelProps) {
+  const [kitData, setKitData] = useState<DailyKitResponse | null>(null)
+  const [ordersData, setOrdersData] = useState<OrdersResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const kitParams = new URLSearchParams({ date })
+      if (technicianId && technicianId !== "all") {
+        kitParams.set("technicianId", technicianId)
+      }
+
+      const kitRes = await fetch(`/api/work-orders/agenda/daily-kit?${kitParams}`)
+      const kitJson: DailyKitResponse | null = kitRes.ok ? await kitRes.json() : null
+      setKitData(kitJson)
+
+      const ordersParams = new URLSearchParams({ from: date, to: date })
+      if (kitJson?.plant_ids?.length) {
+        ordersParams.set("plantIds", kitJson.plant_ids.join(","))
+      }
+
+      const ordersRes = await fetch(`/api/integrations/cotizador/orders?${ordersParams}`)
+      setOrdersData(ordersRes.ok ? await ordersRes.json() : { orders: [], configured: false })
+    } catch {
+      setKitData(null)
+      setOrdersData(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [date, technicianId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const dayLabel = useMemo(
+    () => format(parseISO(date), "EEEE d MMMM yyyy", { locale: es }),
+    [date],
+  )
+
+  const handlePrint = () => {
+    if (onPrint) {
+      onPrint()
+      return
+    }
+    window.print()
+  }
+
+  return (
+    <Card className={cn("print:shadow-none print:border-0", className)} id="agenda-day-detail">
+      <CardHeader className="flex flex-row items-start justify-between gap-4 print:pb-2">
+        <div>
+          <CardTitle className="text-base capitalize">{dayLabel}</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Planeación diaria — insumos y producción programada
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={handlePrint} className="print:hidden">
+          <Printer className="h-4 w-4 mr-2" />
+          Imprimir kit del día
+        </Button>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {loading ? (
+          <div className="h-40 rounded-lg bg-muted animate-pulse" />
+        ) : (
+          <>
+            <section>
+              <div className="flex items-center gap-2 mb-3">
+                <Package className="h-4 w-4" />
+                <h3 className="font-semibold text-sm">Kit de insumos del día</h3>
+                {kitData?.summary && (
+                  <span className="text-xs text-muted-foreground">
+                    {kitData.summary.total_parts} partes · {kitData.summary.insufficient} faltantes
+                  </span>
+                )}
+              </div>
+
+              {!kitData?.kit?.length ? (
+                <p className="text-sm text-muted-foreground">Sin repuestos programados para este día.</p>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Parte</TableHead>
+                      <TableHead className="w-20 text-right">Cant.</TableHead>
+                      <TableHead className="w-24 text-right">Stock</TableHead>
+                      <TableHead className="w-24">Estado</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {kitData.kit.map((line) => (
+                      <TableRow key={line.key}>
+                        <TableCell>
+                          <p className="font-medium text-sm">{line.name}</p>
+                          {line.part_number && (
+                            <p className="text-xs text-muted-foreground">{line.part_number}</p>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">{line.required_quantity}</TableCell>
+                        <TableCell className="text-right">
+                          {line.total_available != null ? line.total_available : "—"}
+                        </TableCell>
+                        <TableCell>
+                          <StockBadge sufficient={line.sufficient} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </section>
+
+            <section>
+              <div className="flex items-center gap-2 mb-3">
+                <Truck className="h-4 w-4" />
+                <h3 className="font-semibold text-sm">Producción del día</h3>
+                <span className="text-xs text-muted-foreground">
+                  Pedidos Cotizador (plantas de activos en agenda)
+                </span>
+              </div>
+
+              {ordersData?.configured === false ? (
+                <p className="text-sm text-muted-foreground">
+                  Integración Cotizador no configurada en este entorno.
+                </p>
+              ) : !ordersData?.orders?.length ? (
+                <p className="text-sm text-muted-foreground">
+                  Sin pedidos de concreto programados para las plantas de la agenda.
+                </p>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Pedido</TableHead>
+                      <TableHead>Hora</TableHead>
+                      <TableHead>Cliente / Obra</TableHead>
+                      <TableHead>Planta</TableHead>
+                      <TableHead>Producto</TableHead>
+                      <TableHead className="text-right">Vol.</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {ordersData.orders.map((row, idx) => (
+                      <TableRow key={`${row.order_id}-${row.product_type}-${idx}`}>
+                        <TableCell className="font-mono text-xs">{row.order_number}</TableCell>
+                        <TableCell>{row.delivery_time?.slice(0, 5) ?? "—"}</TableCell>
+                        <TableCell>
+                          <p className="text-sm">{row.client_name ?? "—"}</p>
+                          <p className="text-xs text-muted-foreground">{row.construction_site}</p>
+                        </TableCell>
+                        <TableCell className="text-sm">{row.plant_name ?? row.plant_id}</TableCell>
+                        <TableCell className="text-sm">{row.product_type}</TableCell>
+                        <TableCell className="text-right">{row.volume ?? "—"}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </section>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/agenda/mechanic-complete-dialog.tsx
+++ b/components/agenda/mechanic-complete-dialog.tsx
@@ -1,0 +1,598 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { format } from "date-fns"
+import Link from "next/link"
+import { Camera, ExternalLink, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { EvidenceUpload, type EvidencePhoto } from "@/components/ui/evidence-upload"
+import { useToast } from "@/hooks/use-toast"
+import { createClient } from "@/lib/supabase"
+import type { AgendaWorkOrder } from "@/lib/agenda/agenda-utils"
+import { taskKeyFromRequiredTask, type TaskCompletionRow } from "@/lib/work-orders/parse-completed-tasks"
+import {
+  getCurrentValue,
+  getMaintenanceUnit,
+  getRawModelMaintenanceUnit,
+  getUnitDisplayName,
+  type MaintenanceUnit,
+} from "@/lib/utils/maintenance-units"
+import { MaintenanceType } from "@/types"
+
+interface MechanicCompleteDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workOrder: Pick<AgendaWorkOrder, "id" | "order_id" | "description"> | null
+  onCompleted?: () => void
+}
+
+type RequiredTask = {
+  id?: string | null
+  description: string
+  type?: string
+}
+
+type PartLine = {
+  part_id: string
+  name: string
+  quantity: number
+  unit_price: number
+  total_price: number
+}
+
+type LoadedWorkOrder = {
+  id: string
+  order_id: string
+  description: string | null
+  type: string
+  asset_id: string | null
+  assigned_to: string | null
+  maintenance_plan_id: string | null
+  asset?: {
+    id: string
+    current_hours?: number | null
+    current_kilometers?: number | null
+    equipment_models?: { maintenance_unit?: string | null } | null
+  } | null
+}
+
+function parseJsonArray<T>(raw: unknown): T[] {
+  if (!raw) return []
+  try {
+    const data = typeof raw === "string" ? JSON.parse(raw) : raw
+    return Array.isArray(data) ? data : []
+  } catch {
+    return []
+  }
+}
+
+function normalizeParts(raw: unknown): PartLine[] {
+  return parseJsonArray<Record<string, unknown>>(raw).map((part, index) => {
+    const qty = Number(part.quantity) || 0
+    const unit = Number(part.unit_price) || 0
+    const name =
+      String(part.name ?? part.part_name ?? part.description ?? "Repuesto").trim() ||
+      "Repuesto"
+    return {
+      part_id: String(part.part_id ?? part.id ?? `part-${index}`),
+      name,
+      quantity: qty,
+      unit_price: unit,
+      total_price: Number(part.total_price) || qty * unit,
+    }
+  })
+}
+
+export function MechanicCompleteDialog({
+  open,
+  onOpenChange,
+  workOrder,
+  onCompleted,
+}: MechanicCompleteDialogProps) {
+  const { toast } = useToast()
+  const [loadingDetails, setLoadingDetails] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [fullOrder, setFullOrder] = useState<LoadedWorkOrder | null>(null)
+  const [requiredTasks, setRequiredTasks] = useState<RequiredTask[]>([])
+  const [completedTasks, setCompletedTasks] = useState<Record<string, boolean>>({})
+  const [parts, setParts] = useState<PartLine[]>([])
+  const [laborHours, setLaborHours] = useState("1")
+  const [notes, setNotes] = useState("")
+  const [equipmentHours, setEquipmentHours] = useState("")
+  const [equipmentKilometers, setEquipmentKilometers] = useState("")
+  const [maintenanceUnit, setMaintenanceUnit] = useState<MaintenanceUnit>("hours")
+  const [rawMaintenanceUnit, setRawMaintenanceUnit] = useState("hours")
+  const [completionEvidence, setCompletionEvidence] = useState<EvidencePhoto[]>([])
+  const [showEvidenceDialog, setShowEvidenceDialog] = useState(false)
+
+  const resetForm = useCallback(() => {
+    setFullOrder(null)
+    setRequiredTasks([])
+    setCompletedTasks({})
+    setParts([])
+    setLaborHours("1")
+    setNotes("")
+    setEquipmentHours("")
+    setEquipmentKilometers("")
+    setCompletionEvidence([])
+  }, [])
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) resetForm()
+    onOpenChange(next)
+  }
+
+  const isPreventive = useMemo(() => {
+    const t = String(fullOrder?.type ?? "").toLowerCase()
+    return t === MaintenanceType.PREVENTIVE || t === "preventivo"
+  }, [fullOrder?.type])
+
+  const loadDetails = useCallback(async (woId: string) => {
+    setLoadingDetails(true)
+    try {
+      const supabase = createClient()
+      const { data: orderData, error } = await supabase
+        .from("work_orders")
+        .select(
+          `id, order_id, description, type, asset_id, assigned_to, maintenance_plan_id,
+           required_tasks, required_parts,
+           asset:assets (id, current_hours, current_kilometers, equipment_models (maintenance_unit))`,
+        )
+        .eq("id", woId)
+        .single()
+
+      if (error || !orderData) throw new Error("No se pudo cargar la orden")
+
+      setFullOrder(orderData as LoadedWorkOrder)
+
+      const unit = getMaintenanceUnit(orderData.asset || {})
+      const rawUnit =
+        getRawModelMaintenanceUnit(orderData.asset?.equipment_models ?? orderData.asset) ??
+        "hours"
+      setMaintenanceUnit(unit)
+      setRawMaintenanceUnit(rawUnit)
+
+      if (orderData.asset) {
+        const current = getCurrentValue(orderData.asset, unit)
+        if (unit === "kilometers") {
+          setEquipmentKilometers(String(current))
+        } else {
+          setEquipmentHours(String(current))
+        }
+        if (rawUnit === "both") {
+          setEquipmentKilometers(String(Number(orderData.asset.current_kilometers) || 0))
+        }
+      }
+
+      const tasks = parseJsonArray<RequiredTask>(orderData.required_tasks)
+      setRequiredTasks(tasks)
+      const initialCompleted: Record<string, boolean> = {}
+      tasks.forEach((task, index) => {
+        initialCompleted[taskKeyFromRequiredTask(task, index)] = false
+      })
+      setCompletedTasks(initialCompleted)
+
+      let loadedParts = normalizeParts(orderData.required_parts)
+
+      const { data: linkedPos } = await supabase
+        .from("purchase_orders")
+        .select("id, items, is_adjustment, actual_amount, total_amount")
+        .eq("work_order_id", woId)
+        .order("created_at", { ascending: true })
+
+      const mainPo = (linkedPos ?? []).find((po) => !po.is_adjustment && po.items)
+      if (mainPo?.items) {
+        const poParts = normalizeParts(mainPo.items)
+        if (poParts.length > 0) loadedParts = poParts
+      }
+
+      setParts(loadedParts)
+    } catch (e) {
+      toast({
+        title: "Error",
+        description: e instanceof Error ? e.message : "No se pudo cargar la OT",
+        variant: "destructive",
+      })
+      handleOpenChange(false)
+    } finally {
+      setLoadingDetails(false)
+    }
+  }, [toast])
+
+  useEffect(() => {
+    if (open && workOrder?.id) {
+      void loadDetails(workOrder.id)
+    }
+  }, [open, workOrder?.id, loadDetails])
+
+  const tasksDoneCount = Object.values(completedTasks).filter(Boolean).length
+  const allTasksDone =
+    requiredTasks.length === 0 || tasksDoneCount === requiredTasks.length
+
+  const updatePartQuantity = (partId: string, qty: number) => {
+    setParts((prev) =>
+      prev.map((p) =>
+        p.part_id === partId
+          ? {
+              ...p,
+              quantity: qty,
+              total_price: qty * p.unit_price,
+            }
+          : p,
+      ),
+    )
+  }
+
+  const validate = (): string | null => {
+    if (!notes.trim()) return "Indique qué se realizó en el trabajo."
+    if (requiredTasks.length > 0 && !allTasksDone) {
+      return "Marque todas las tareas requeridas antes de completar."
+    }
+    if (isPreventive && fullOrder?.maintenance_plan_id) {
+      const meter =
+        maintenanceUnit === "kilometers"
+          ? Number(equipmentKilometers) || 0
+          : Number(equipmentHours) || 0
+      if (meter <= 0) {
+        return `Indique la lectura de ${getUnitDisplayName(maintenanceUnit)} del equipo.`
+      }
+    }
+    for (const part of parts) {
+      if (Number.isNaN(part.quantity) || part.quantity < 0) {
+        return `Cantidad inválida para ${part.name}.`
+      }
+    }
+    return null
+  }
+
+  const handleSave = async () => {
+    if (!workOrder || !fullOrder) return
+    const validationError = validate()
+    if (validationError) {
+      toast({
+        title: "Falta información",
+        description: validationError,
+        variant: "destructive",
+      })
+      return
+    }
+
+    setSaving(true)
+    try {
+      const now = new Date()
+      const labor = Number(laborHours) || 0
+      const completionDate = now.toISOString()
+      const partsUsed = parts.map((p) => ({
+        part_id: p.part_id,
+        name: p.name,
+        quantity: p.quantity,
+        unit_price: p.unit_price,
+        total_price: p.total_price,
+      }))
+      const partsCost = partsUsed.reduce((s, p) => s + p.total_price, 0)
+
+      const completedAtIso = completionDate
+      const completedTasksPayload: TaskCompletionRow[] | null =
+        requiredTasks.length > 0
+          ? requiredTasks.map((task, index) => {
+              const key = taskKeyFromRequiredTask(task, index)
+              return {
+                task_id: key,
+                description: task.description,
+                completed: completedTasks[key] === true,
+                completed_at: completedTasks[key] === true ? completedAtIso : undefined,
+              }
+            })
+          : null
+
+      const equipmentHoursVal =
+        maintenanceUnit === "hours" || rawMaintenanceUnit === "both"
+          ? Number(equipmentHours) || null
+          : null
+      const equipmentKmVal =
+        maintenanceUnit === "kilometers" || rawMaintenanceUnit === "both"
+          ? Number(equipmentKilometers) || null
+          : null
+
+      const payload = {
+        workOrderId: workOrder.id,
+        completionData: {
+          resolution_details: notes.trim(),
+          technician_notes: notes.trim(),
+          downtime_hours: 0,
+          labor_hours: labor,
+          labor_cost: 0,
+          total_cost: partsCost,
+          completion_date: completionDate,
+          completion_time: format(now, "HH:mm"),
+          parts_used: partsUsed,
+          completed_tasks: completedTasksPayload ?? undefined,
+          equipment_hours: equipmentHoursVal,
+          equipment_kilometers: equipmentKmVal,
+          completion_photos: completionEvidence.map((evidence) => ({
+            url: evidence.url,
+            description: evidence.description,
+            category: evidence.category,
+            uploaded_at: evidence.uploaded_at,
+            bucket_path: evidence.bucket_path,
+          })),
+        },
+        maintenanceHistoryData: fullOrder.asset_id
+          ? {
+              asset_id: fullOrder.asset_id,
+              date: completionDate,
+              type: fullOrder.type,
+              description: fullOrder.description ?? workOrder.description,
+              technician_id: fullOrder.assigned_to,
+              labor_hours: labor,
+              labor_cost: "0",
+              parts: partsUsed.length > 0 ? partsUsed : null,
+              total_cost: String(partsCost),
+              work_order_id: workOrder.id,
+              findings: notes.trim(),
+              actions: notes.trim(),
+              resolution_details: notes.trim(),
+              technician_notes: notes.trim(),
+              downtime_hours: 0,
+              hours: equipmentHoursVal,
+              kilometers: equipmentKmVal,
+              completed_tasks: completedTasksPayload,
+            }
+          : null,
+      }
+
+      const res = await fetch("/api/maintenance/work-completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error ?? "No se pudo completar la orden")
+      }
+
+      toast({
+        title: "Trabajo completado",
+        description: `OT ${workOrder.order_id} registrada como completada.`,
+      })
+      onCompleted?.()
+      handleOpenChange(false)
+    } catch (e) {
+      toast({
+        title: "Error",
+        description: e instanceof Error ? e.message : "No se pudo completar",
+        variant: "destructive",
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!workOrder) return null
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-lg max-h-[min(90vh,720px)] flex flex-col p-0 gap-0">
+          <DialogHeader className="px-6 pt-6 pb-2 shrink-0">
+            <DialogTitle>Completar trabajo</DialogTitle>
+            <DialogDescription>
+              OT {workOrder.order_id} — registro de campo con tareas, repuestos y evidencia.
+            </DialogDescription>
+          </DialogHeader>
+
+          {loadingDetails ? (
+            <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Cargando orden…
+            </div>
+          ) : (
+            <ScrollArea className="flex-1 min-h-0 px-6">
+              <div className="space-y-5 py-2 pr-3">
+                <p className="text-sm text-muted-foreground">{workOrder.description}</p>
+
+                {requiredTasks.length > 0 && (
+                  <section className="space-y-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <Label className="text-sm font-medium">Tareas requeridas</Label>
+                      <Badge variant={allTasksDone ? "default" : "secondary"}>
+                        {tasksDoneCount}/{requiredTasks.length}
+                      </Badge>
+                    </div>
+                    <ul className="space-y-2 rounded-lg border p-3">
+                      {requiredTasks.map((task, index) => {
+                        const key = taskKeyFromRequiredTask(task, index)
+                        return (
+                          <li key={key} className="flex items-start gap-3">
+                            <Checkbox
+                              id={`task-${key}`}
+                              checked={completedTasks[key] ?? false}
+                              onCheckedChange={(checked) =>
+                                setCompletedTasks((prev) => ({
+                                  ...prev,
+                                  [key]: checked === true,
+                                }))
+                              }
+                              className="mt-0.5"
+                            />
+                            <label
+                              htmlFor={`task-${key}`}
+                              className="text-sm leading-snug cursor-pointer"
+                            >
+                              {task.description}
+                            </label>
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  </section>
+                )}
+
+                {parts.length > 0 && (
+                  <section className="space-y-2">
+                    <Label className="text-sm font-medium">Repuestos utilizados</Label>
+                    <ul className="space-y-2 rounded-lg border p-3">
+                      {parts.map((part) => (
+                        <li
+                          key={part.part_id}
+                          className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                          <span className="text-sm flex-1 min-w-0 truncate">{part.name}</span>
+                          <div className="flex items-center gap-2 shrink-0">
+                            <Label htmlFor={`qty-${part.part_id}`} className="sr-only">
+                              Cantidad
+                            </Label>
+                            <Input
+                              id={`qty-${part.part_id}`}
+                              type="number"
+                              min={0}
+                              step={1}
+                              className="w-20 h-8"
+                              value={part.quantity}
+                              onChange={(e) =>
+                                updatePartQuantity(part.part_id, Number(e.target.value) || 0)
+                              }
+                            />
+                            <span className="text-xs text-muted-foreground w-8">uds</span>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {isPreventive && fullOrder?.maintenance_plan_id && (
+                  <section className="space-y-2">
+                    <Label className="text-sm font-medium">
+                      Lectura del equipo ({getUnitDisplayName(maintenanceUnit)})
+                    </Label>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                      {(maintenanceUnit === "hours" || rawMaintenanceUnit === "both") && (
+                        <div className="space-y-1">
+                          <Label htmlFor="equip-hours" className="text-xs text-muted-foreground">
+                            Horas
+                          </Label>
+                          <Input
+                            id="equip-hours"
+                            type="number"
+                            min={0}
+                            step={0.1}
+                            value={equipmentHours}
+                            onChange={(e) => setEquipmentHours(e.target.value)}
+                          />
+                        </div>
+                      )}
+                      {(maintenanceUnit === "kilometers" || rawMaintenanceUnit === "both") && (
+                        <div className="space-y-1">
+                          <Label htmlFor="equip-km" className="text-xs text-muted-foreground">
+                            Kilómetros
+                          </Label>
+                          <Input
+                            id="equip-km"
+                            type="number"
+                            min={0}
+                            step={1}
+                            value={equipmentKilometers}
+                            onChange={(e) => setEquipmentKilometers(e.target.value)}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  </section>
+                )}
+
+                <section className="space-y-2">
+                  <Label htmlFor="labor-hours">Horas de trabajo</Label>
+                  <Input
+                    id="labor-hours"
+                    type="number"
+                    min={0}
+                    step={0.5}
+                    value={laborHours}
+                    onChange={(e) => setLaborHours(e.target.value)}
+                  />
+                </section>
+
+                <section className="space-y-2">
+                  <Label htmlFor="completion-notes">¿Qué se realizó?</Label>
+                  <Textarea
+                    id="completion-notes"
+                    rows={3}
+                    placeholder="Descripción del trabajo realizado…"
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                  />
+                </section>
+
+                <section className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label>Evidencia fotográfica</Label>
+                    <Badge variant="outline">{completionEvidence.length} foto(s)</Badge>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    onClick={() => setShowEvidenceDialog(true)}
+                  >
+                    <Camera className="mr-2 h-4 w-4" />
+                    {completionEvidence.length > 0 ? "Gestionar fotos" : "Agregar fotos (opcional)"}
+                  </Button>
+                </section>
+
+                <Separator />
+
+                <p className="text-xs text-muted-foreground">
+                  ¿Gastos adicionales, ajuste de OC o más detalle?{" "}
+                  <Link
+                    href={`/ordenes/${workOrder.id}/completar`}
+                    className="text-primary inline-flex items-center gap-1 hover:underline"
+                  >
+                    Formulario completo
+                    <ExternalLink className="h-3 w-3" />
+                  </Link>
+                </p>
+              </div>
+            </ScrollArea>
+          )}
+
+          <DialogFooter className="px-6 py-4 border-t shrink-0 flex-col-reverse sm:flex-row gap-2">
+            <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={saving}>
+              Cancelar
+            </Button>
+            <Button onClick={handleSave} disabled={saving || loadingDetails}>
+              {saving ? "Guardando…" : "Marcar completada"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <EvidenceUpload
+        open={showEvidenceDialog}
+        onOpenChange={setShowEvidenceDialog}
+        evidence={completionEvidence}
+        setEvidence={setCompletionEvidence}
+        context="completion"
+        workOrderId={workOrder.id}
+        operatorSimple
+      />
+    </>
+  )
+}

--- a/components/agenda/mechanic-work-sheet.tsx
+++ b/components/agenda/mechanic-work-sheet.tsx
@@ -94,18 +94,20 @@ export function MechanicWorkSheet() {
             ] as string[]
 
             const remisionesByAsset = new Map<string, RemisionRow[]>()
-            await Promise.all(
-              dayAssets.map(async (assetCode) => {
-                const remParams = new URLSearchParams({
-                  assetId: assetCode,
-                  from: dayKey,
-                  to: dayKey,
-                })
-                const remRes = await fetch(`/api/integrations/cotizador/remisiones?${remParams}`)
-                const remJson = remRes.ok ? await remRes.json() : { remisiones: [] }
-                remisionesByAsset.set(assetCode, remJson.remisiones ?? [])
-              }),
-            )
+            if (dayAssets.length > 0) {
+              const remParams = new URLSearchParams({
+                assetIds: dayAssets.join(","),
+                from: dayKey,
+                to: dayKey,
+              })
+              const remRes = await fetch(`/api/integrations/cotizador/remisiones?${remParams}`)
+              const remJson = remRes.ok ? await remRes.json() : { remisiones_by_asset: {} }
+              for (const [assetCode, rows] of Object.entries(
+                remJson.remisiones_by_asset ?? {},
+              )) {
+                remisionesByAsset.set(assetCode, rows as RemisionRow[])
+              }
+            }
 
             contextMap.set(dayKey, {
               kitByWo,

--- a/components/agenda/mechanic-work-sheet.tsx
+++ b/components/agenda/mechanic-work-sheet.tsx
@@ -1,41 +1,127 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useSearchParams } from "next/navigation"
 import { format, parseISO } from "date-fns"
 import { es } from "date-fns/locale"
 import Link from "next/link"
+import type { CotizadorOrderItemRow } from "@/lib/agenda/cotizador-orders"
+import type { DailyKitWorkOrderParts } from "@/app/api/work-orders/agenda/daily-kit/route"
+import type { RemisionRow } from "@/app/api/integrations/cotizador/remisiones/route"
+import { useAuthZustand } from "@/hooks/use-auth-zustand"
 import { Button } from "@/components/ui/button"
+import { MechanicCompleteDialog } from "@/components/agenda/mechanic-complete-dialog"
 import { ORIGIN_LABELS, type AgendaWorkOrder } from "@/lib/agenda/agenda-utils"
+import { WorkOrderStatus } from "@/types"
+import { useToast } from "@/hooks/use-toast"
+
+type DayContext = {
+  kitByWo: Map<string, DailyKitWorkOrderParts>
+  orders: CotizadorOrderItemRow[]
+  remisionesByAsset: Map<string, RemisionRow[]>
+}
 
 export function MechanicWorkSheet() {
   const searchParams = useSearchParams()
-  const from = searchParams.get("from") ?? ""
-  const to = searchParams.get("to") ?? ""
-  const technicianId = searchParams.get("technician")
+  const { profile } = useAuthZustand()
+  const { toast } = useToast()
+
+  const today = format(new Date(), "yyyy-MM-dd")
+  const from = searchParams.get("from") ?? today
+  const to = searchParams.get("to") ?? from
+  const technicianId = searchParams.get("technician") ?? profile?.id ?? undefined
 
   const [items, setItems] = useState<AgendaWorkOrder[]>([])
   const [technicianName, setTechnicianName] = useState("Todos los técnicos")
+  const [dayContext, setDayContext] = useState<Map<string, DayContext>>(new Map())
   const [loading, setLoading] = useState(true)
+  const [completeTarget, setCompleteTarget] = useState<AgendaWorkOrder | null>(null)
+  const [statusBusyId, setStatusBusyId] = useState<string | null>(null)
 
-  useEffect(() => {
-    if (!from || !to) return
+  const loadAgenda = useCallback(() => {
     const params = new URLSearchParams({ from, to })
     if (technicianId) params.set("assigned_to", technicianId)
 
-    fetch(`/api/work-orders/agenda?${params}`)
+    setLoading(true)
+    return fetch(`/api/work-orders/agenda?${params}`)
       .then((r) => (r.ok ? r.json() : { scheduled: [], technicians: [] }))
-      .then((data) => {
-        setItems(data.scheduled ?? [])
+      .then(async (data) => {
+        const scheduled: AgendaWorkOrder[] = data.scheduled ?? []
+        setItems(scheduled)
         if (technicianId) {
           const tech = (data.technicians ?? []).find(
             (t: { id: string; name: string }) => t.id === technicianId,
           )
           if (tech) setTechnicianName(tech.name)
+          else if (profile) {
+            setTechnicianName(
+              [profile.nombre, profile.apellido].filter(Boolean).join(" ") || "Técnico",
+            )
+          }
         }
+
+        const dayKeys = [
+          ...new Set(scheduled.map((wo) => wo.planned_date?.slice(0, 10)).filter(Boolean)),
+        ] as string[]
+
+        const contextMap = new Map<string, DayContext>()
+        await Promise.all(
+          dayKeys.map(async (dayKey) => {
+            const kitParams = new URLSearchParams({ date: dayKey })
+            if (technicianId) kitParams.set("technicianId", technicianId)
+
+            const kitRes = await fetch(`/api/work-orders/agenda/daily-kit?${kitParams}`)
+            const kitJson = kitRes.ok ? await kitRes.json() : null
+            const kitByWo = new Map<string, DailyKitWorkOrderParts>()
+            for (const row of kitJson?.by_work_order ?? []) {
+              kitByWo.set(row.work_order_id, row)
+            }
+
+            const ordersParams = new URLSearchParams({ from: dayKey, to: dayKey })
+            if (kitJson?.plant_ids?.length) {
+              ordersParams.set("plantIds", kitJson.plant_ids.join(","))
+            }
+            const ordersRes = await fetch(`/api/integrations/cotizador/orders?${ordersParams}`)
+            const ordersJson = ordersRes.ok ? await ordersRes.json() : { orders: [] }
+
+            const dayAssets = [
+              ...new Set(
+                scheduled
+                  .filter((wo) => wo.planned_date?.slice(0, 10) === dayKey)
+                  .map((wo) => wo.asset_code)
+                  .filter(Boolean),
+              ),
+            ] as string[]
+
+            const remisionesByAsset = new Map<string, RemisionRow[]>()
+            await Promise.all(
+              dayAssets.map(async (assetCode) => {
+                const remParams = new URLSearchParams({
+                  assetId: assetCode,
+                  from: dayKey,
+                  to: dayKey,
+                })
+                const remRes = await fetch(`/api/integrations/cotizador/remisiones?${remParams}`)
+                const remJson = remRes.ok ? await remRes.json() : { remisiones: [] }
+                remisionesByAsset.set(assetCode, remJson.remisiones ?? [])
+              }),
+            )
+
+            contextMap.set(dayKey, {
+              kitByWo,
+              orders: ordersJson.orders ?? [],
+              remisionesByAsset,
+            })
+          }),
+        )
+        setDayContext(contextMap)
       })
       .finally(() => setLoading(false))
-  }, [from, to, technicianId])
+  }, [from, to, technicianId, profile])
+
+  useEffect(() => {
+    loadAgenda()
+  }, [loadAgenda])
 
   const byDay = useMemo(() => {
     const map = new Map<string, AgendaWorkOrder[]>()
@@ -48,16 +134,34 @@ export function MechanicWorkSheet() {
     return [...map.entries()].sort(([a], [b]) => a.localeCompare(b))
   }, [items])
 
-  if (!from || !to) {
-    return (
-      <p className="text-sm text-muted-foreground p-8">
-        Parámetros from y to requeridos.{" "}
-        <Link href="/ordenes/agenda" className="underline">
-          Volver a la agenda
-        </Link>
-      </p>
-    )
+  const handleStartWork = async (wo: AgendaWorkOrder) => {
+    setStatusBusyId(wo.id)
+    try {
+      const res = await fetch(`/api/work-orders/${wo.id}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "En ejecución" }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error ?? "No se pudo iniciar el trabajo")
+      }
+      toast({ title: "Trabajo iniciado", description: `OT ${wo.order_id} en ejecución.` })
+      await loadAgenda()
+    } catch (e) {
+      toast({
+        title: "Error",
+        description: e instanceof Error ? e.message : "No se pudo actualizar",
+        variant: "destructive",
+      })
+    } finally {
+      setStatusBusyId(null)
+    }
   }
+
+  const isCompleted = (status: string) => status === WorkOrderStatus.Completed
+  const isInProgress = (status: string) =>
+    status === "En ejecución" || status === "En Progreso"
 
   return (
     <div className="print:p-0 p-6 max-w-4xl mx-auto bg-white text-black min-h-screen">
@@ -69,13 +173,19 @@ export function MechanicWorkSheet() {
       </div>
 
       <header className="border-b-2 border-black pb-4 mb-6">
-        <h1 className="text-2xl font-bold">Hoja de trabajo — Mantenimiento</h1>
+        <h1 className="text-2xl font-bold">Orden del día — Mantenimiento</h1>
         <p className="text-sm mt-1">
           Técnico: <strong>{technicianName}</strong>
         </p>
         <p className="text-sm">
-          Periodo: {format(parseISO(from), "d MMM yyyy", { locale: es })} –{" "}
-          {format(parseISO(to), "d MMM yyyy", { locale: es })}
+          {from === to ? (
+            <>Fecha: {format(parseISO(from), "d MMM yyyy", { locale: es })}</>
+          ) : (
+            <>
+              Periodo: {format(parseISO(from), "d MMM yyyy", { locale: es })} –{" "}
+              {format(parseISO(to), "d MMM yyyy", { locale: es })}
+            </>
+          )}
         </p>
         <p className="text-xs text-gray-600 mt-2">
           Generado {format(new Date(), "PPpp", { locale: es })}
@@ -88,51 +198,160 @@ export function MechanicWorkSheet() {
         <p>No hay trabajos programados en este periodo.</p>
       ) : (
         <div className="space-y-8">
-          {byDay.map(([dayKey, dayItems]) => (
-            <section key={dayKey}>
-              <h2 className="text-lg font-semibold border-b border-gray-400 mb-3 capitalize">
-                {format(parseISO(dayKey), "EEEE d MMMM", { locale: es })}
-              </h2>
-              <table className="w-full text-sm border-collapse">
-                <thead>
-                  <tr className="border-b border-gray-300 text-left">
-                    <th className="py-2 pr-2 w-20">OT</th>
-                    <th className="py-2 pr-2 w-24">Unidad</th>
-                    <th className="py-2 pr-2">Trabajo</th>
-                    <th className="py-2 pr-2 w-16">Prior.</th>
-                    <th className="py-2 w-24">Hecho</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {dayItems.map((wo) => (
-                    <tr key={wo.id} className="border-b border-gray-200 align-top">
-                      <td className="py-3 pr-2 font-mono text-xs">{wo.order_id}</td>
-                      <td className="py-3 pr-2">{wo.asset_code ?? wo.asset_name}</td>
-                      <td className="py-3 pr-2">
-                        <p>{wo.description}</p>
-                        <p className="text-xs text-gray-500 mt-1">
-                          {ORIGIN_LABELS[wo.origin]}
-                          {wo.hours_open != null && wo.origin === "incident"
-                            ? ` · ${wo.hours_open}d abierto`
-                            : ""}
-                        </p>
-                      </td>
-                      <td className="py-3 pr-2">{wo.priority ?? "—"}</td>
-                      <td className="py-3">
-                        <span className="inline-block w-5 h-5 border border-gray-400" />
-                      </td>
+          {byDay.map(([dayKey, dayItems]) => {
+            const ctx = dayContext.get(dayKey)
+            return (
+              <section key={dayKey}>
+                <h2 className="text-lg font-semibold border-b border-gray-400 mb-3 capitalize">
+                  {format(parseISO(dayKey), "EEEE d MMMM", { locale: es })}
+                </h2>
+
+                {ctx && ctx.orders.length > 0 && (
+                  <div className="mb-4 text-xs border border-gray-300 rounded p-3">
+                    <p className="font-semibold mb-2">Producción programada (planta)</p>
+                    <ul className="space-y-1">
+                      {ctx.orders.slice(0, 8).map((o, idx) => (
+                        <li key={`${o.order_id}-${idx}`}>
+                          #{o.order_number} · {o.delivery_time?.slice(0, 5) ?? "—"} ·{" "}
+                          {o.client_name} · {o.volume ?? "—"} m³
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                <table className="w-full text-sm border-collapse">
+                  <thead>
+                    <tr className="border-b border-gray-300 text-left">
+                      <th className="py-2 pr-2 w-20">OT</th>
+                      <th className="py-2 pr-2 w-24">Unidad</th>
+                      <th className="py-2 pr-2">Trabajo / Insumos</th>
+                      <th className="py-2 pr-2 w-16">Prior.</th>
+                      <th className="py-2 w-24 print:w-24">Hecho</th>
+                      <th className="py-2 w-36 print:hidden">Acciones</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </section>
-          ))}
+                  </thead>
+                  <tbody>
+                    {dayItems.map((wo) => {
+                      const kit = ctx?.kitByWo.get(wo.id)
+                      const remisiones = wo.asset_code
+                        ? ctx?.remisionesByAsset.get(wo.asset_code) ?? []
+                        : []
+                      const done = isCompleted(wo.status)
+                      const inProgress = isInProgress(wo.status)
+                      return (
+                        <tr
+                          key={wo.id}
+                          className={`border-b border-gray-200 align-top ${
+                            done ? "bg-green-50/80 print:bg-transparent" : ""
+                          }`}
+                        >
+                          <td className="py-3 pr-2 font-mono text-xs">{wo.order_id}</td>
+                          <td className="py-3 pr-2">{wo.asset_code ?? wo.asset_name}</td>
+                          <td className="py-3 pr-2">
+                            <p>{wo.description}</p>
+                            <p className="text-xs text-gray-500 mt-1">
+                              {ORIGIN_LABELS[wo.origin]} ·{" "}
+                              {done ? (
+                                <span className="text-green-700 font-medium">Completada</span>
+                              ) : inProgress ? (
+                                <span className="text-amber-700 font-medium">En ejecución</span>
+                              ) : (
+                                wo.status
+                              )}
+                              {wo.hours_open != null && wo.origin === "incident"
+                                ? ` · ${wo.hours_open}d abierto`
+                                : ""}
+                            </p>
+                            {kit && kit.parts.length > 0 && (
+                              <ul className="mt-2 text-xs text-gray-700 list-disc pl-4">
+                                {kit.parts.map((p) => (
+                                  <li key={`${p.part_id ?? p.part_number}-${p.name}`}>
+                                    {p.quantity}× {p.name}
+                                    {p.part_number ? ` (${p.part_number})` : ""}
+                                    {p.sufficient === false ? " — faltante" : ""}
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                            {remisiones.length > 0 && (
+                              <p className="text-xs text-gray-600 mt-2">
+                                Remisiones:{" "}
+                                {remisiones
+                                  .map(
+                                    (r) =>
+                                      `${r.remision_number} (${r.volumen_fabricado ?? "—"} m³)`,
+                                  )
+                                  .join(", ")}
+                              </p>
+                            )}
+                          </td>
+                          <td className="py-3 pr-2">{wo.priority ?? "—"}</td>
+                          <td className="py-3">
+                            {done ? (
+                              <span className="text-green-700 text-xs font-semibold">✓ Hecho</span>
+                            ) : (
+                              <span className="inline-block w-5 h-5 border border-gray-400" />
+                            )}
+                          </td>
+                          <td className="py-3 print:hidden">
+                            {done ? (
+                              <Link
+                                href={`/ordenes/${wo.id}`}
+                                className="text-[11px] text-primary hover:underline"
+                              >
+                                Ver OT
+                              </Link>
+                            ) : (
+                              <div className="flex flex-col gap-1">
+                                {!isInProgress(wo.status) && (
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    className="h-7 text-xs"
+                                    disabled={statusBusyId === wo.id}
+                                    onClick={() => handleStartWork(wo)}
+                                  >
+                                    Iniciar
+                                  </Button>
+                                )}
+                                <Button
+                                  size="sm"
+                                  className="h-7 text-xs"
+                                  onClick={() => setCompleteTarget(wo)}
+                                >
+                                  Completar
+                                </Button>
+                                <Link
+                                  href={`/ordenes/${wo.id}/completar`}
+                                  className="text-[11px] text-primary hover:underline"
+                                >
+                                  Formulario completo
+                                </Link>
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </section>
+            )
+          })}
         </div>
       )}
 
       <footer className="mt-12 pt-4 border-t text-xs text-gray-500 print:mt-8">
         Firmas: Técnico _________________ Supervisor _________________
       </footer>
+
+      <MechanicCompleteDialog
+        open={!!completeTarget}
+        onOpenChange={(open) => !open && setCompleteTarget(null)}
+        workOrder={completeTarget}
+        onCompleted={loadAgenda}
+      />
     </div>
   )
 }

--- a/components/agenda/plan-work-order-dialog.tsx
+++ b/components/agenda/plan-work-order-dialog.tsx
@@ -95,7 +95,7 @@ export function PlanWorkOrderDialog({
     setStatus(workOrder.status || WorkOrderStatus.Pending)
     setPriority(workOrder.priority || ServiceOrderPriority.Medium)
 
-    fetch("/api/work-orders/agenda?from=2000-01-01&to=2099-12-31")
+    fetch("/api/work-orders/agenda?technicians_only=true&from=1970-01-01&to=1970-01-01")
       .then((r) => (r.ok ? r.json() : { technicians: [] }))
       .then((data) => setTechnicians(data.technicians ?? []))
       .catch(() => setTechnicians([]))
@@ -104,7 +104,7 @@ export function PlanWorkOrderDialog({
   const handleSave = async () => {
     if (!workOrder) return
 
-    if (!plannedDate && !assignedTo) {
+    if (!plannedDate && !assignedTo && !workOrder.planned_date && !workOrder.assigned_to) {
       toast({
         title: "Datos incompletos",
         description: "Seleccione al menos un técnico o una fecha.",
@@ -119,9 +119,7 @@ export function PlanWorkOrderDialog({
       if (plannedDate) {
         body.planned_date = format(plannedDate, "yyyy-MM-dd")
       }
-      if (assignedTo) {
-        body.assigned_to = assignedTo
-      }
+      body.assigned_to = assignedTo || null
       if (status) {
         body.status = status
       }

--- a/components/agenda/plan-work-order-dialog.tsx
+++ b/components/agenda/plan-work-order-dialog.tsx
@@ -1,0 +1,284 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { format, parseISO } from "date-fns"
+import { es } from "date-fns/locale"
+import { CalendarIcon, ExternalLink } from "lucide-react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import { useToast } from "@/hooks/use-toast"
+import { ServiceOrderPriority, WorkOrderStatus } from "@/types"
+import { ORIGIN_LABELS, type AgendaWorkOrder } from "@/lib/agenda/agenda-utils"
+
+export type PlanWorkOrderSummary = Pick<
+  AgendaWorkOrder,
+  | "id"
+  | "order_id"
+  | "description"
+  | "priority"
+  | "status"
+  | "planned_date"
+  | "assigned_to"
+  | "asset_code"
+  | "asset_name"
+  | "origin"
+  | "technician_name"
+>
+
+interface PlanWorkOrderDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workOrder: PlanWorkOrderSummary | null
+  defaultPlannedDate?: string
+  onSaved?: () => void
+}
+
+const STATUS_OPTIONS = [
+  WorkOrderStatus.Pending,
+  WorkOrderStatus.Programmed,
+  WorkOrderStatus.WaitingParts,
+] as const
+
+const PRIORITY_OPTIONS = [
+  ServiceOrderPriority.Low,
+  ServiceOrderPriority.Medium,
+  ServiceOrderPriority.High,
+  ServiceOrderPriority.Critical,
+] as const
+
+export function PlanWorkOrderDialog({
+  open,
+  onOpenChange,
+  workOrder,
+  defaultPlannedDate,
+  onSaved,
+}: PlanWorkOrderDialogProps) {
+  const { toast } = useToast()
+  const [plannedDate, setPlannedDate] = useState<Date | undefined>()
+  const [assignedTo, setAssignedTo] = useState<string>("")
+  const [status, setStatus] = useState<string>(WorkOrderStatus.Pending)
+  const [priority, setPriority] = useState<string>(ServiceOrderPriority.Medium)
+  const [technicians, setTechnicians] = useState<Array<{ id: string; name: string }>>([])
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!open || !workOrder) return
+
+    setPlannedDate(
+      workOrder.planned_date
+        ? parseISO(workOrder.planned_date.slice(0, 10))
+        : defaultPlannedDate
+          ? parseISO(defaultPlannedDate)
+          : undefined,
+    )
+    setAssignedTo(workOrder.assigned_to ?? "")
+    setStatus(workOrder.status || WorkOrderStatus.Pending)
+    setPriority(workOrder.priority || ServiceOrderPriority.Medium)
+
+    fetch("/api/work-orders/agenda?from=2000-01-01&to=2099-12-31")
+      .then((r) => (r.ok ? r.json() : { technicians: [] }))
+      .then((data) => setTechnicians(data.technicians ?? []))
+      .catch(() => setTechnicians([]))
+  }, [open, workOrder, defaultPlannedDate])
+
+  const handleSave = async () => {
+    if (!workOrder) return
+
+    if (!plannedDate && !assignedTo) {
+      toast({
+        title: "Datos incompletos",
+        description: "Seleccione al menos un técnico o una fecha.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setSaving(true)
+    try {
+      const body: Record<string, string | null> = {}
+      if (plannedDate) {
+        body.planned_date = format(plannedDate, "yyyy-MM-dd")
+      }
+      if (assignedTo) {
+        body.assigned_to = assignedTo
+      }
+      if (status) {
+        body.status = status
+      }
+      if (priority) {
+        body.priority = priority
+      }
+
+      const res = await fetch(`/api/work-orders/${workOrder.id}/schedule`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error ?? "Error al programar")
+      }
+
+      toast({
+        title: "Trabajo programado",
+        description: "La orden quedó actualizada en la agenda.",
+      })
+      onSaved?.()
+      onOpenChange(false)
+    } catch (e) {
+      toast({
+        title: "Error",
+        description: e instanceof Error ? e.message : "No se pudo programar",
+        variant: "destructive",
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!workOrder) return null
+
+  const assetLabel = workOrder.asset_code ?? workOrder.asset_name ?? "Sin activo"
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Planificar orden de trabajo</DialogTitle>
+          <DialogDescription>
+            Asigne fecha, técnico y estado sin abrir el formulario completo de la OT.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-lg border bg-muted/30 p-3 space-y-2 text-sm">
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-semibold font-mono">{workOrder.order_id}</span>
+            <Badge variant="outline" className="text-xs">
+              {ORIGIN_LABELS[workOrder.origin]}
+            </Badge>
+          </div>
+          <p className="text-muted-foreground">{assetLabel}</p>
+          <p className="line-clamp-3">{workOrder.description}</p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 py-1">
+          <div className="space-y-2 sm:col-span-2">
+            <Label>Mecánico</Label>
+            <Select value={assignedTo || "none"} onValueChange={(v) => setAssignedTo(v === "none" ? "" : v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Seleccionar técnico" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Sin asignar</SelectItem>
+                {technicians.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Fecha programada</Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className={cn(
+                    "w-full justify-start text-left font-normal",
+                    !plannedDate && "text-muted-foreground",
+                  )}
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {plannedDate
+                    ? format(plannedDate, "PPP", { locale: es })
+                    : "Elegir fecha"}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={plannedDate}
+                  onSelect={setPlannedDate}
+                  locale={es}
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Estado</Label>
+            <Select value={status} onValueChange={setStatus}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_OPTIONS.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2 sm:col-span-2">
+            <Label>Prioridad</Label>
+            <Select value={priority} onValueChange={setPriority}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PRIORITY_OPTIONS.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href={`/ordenes/${workOrder.id}`}>
+              <ExternalLink className="h-4 w-4 mr-2" />
+              Ver OT completa
+            </Link>
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancelar
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? "Guardando…" : "Guardar planificación"}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/agenda/work-agenda-board.tsx
+++ b/components/agenda/work-agenda-board.tsx
@@ -4,7 +4,9 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { addWeeks, endOfWeek, format, parseISO, startOfWeek, subWeeks } from "date-fns"
 import { es } from "date-fns/locale"
-import { CalendarDays, ChevronLeft, ChevronRight, Printer, Wrench } from "lucide-react"
+import { CalendarDays, ChevronLeft, ChevronRight, CalendarPlus, Printer, Wrench } from "lucide-react"
+import { AgendaDayDetailPanel } from "@/components/agenda/agenda-day-detail-panel"
+import { PlanWorkOrderDialog, type PlanWorkOrderSummary } from "@/components/agenda/plan-work-order-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -36,10 +38,13 @@ interface WorkAgendaBoardProps {
 export function WorkAgendaBoard({ initialTechnicianId }: WorkAgendaBoardProps) {
   const [anchor, setAnchor] = useState(() => new Date())
   const [technicianId, setTechnicianId] = useState(initialTechnicianId ?? "all")
+  const [selectedDay, setSelectedDay] = useState<string | null>(null)
   const [scheduled, setScheduled] = useState<AgendaWorkOrder[]>([])
   const [unscheduled, setUnscheduled] = useState<AgendaWorkOrder[]>([])
   const [technicians, setTechnicians] = useState<Technician[]>([])
   const [loading, setLoading] = useState(true)
+  const [planningOrder, setPlanningOrder] = useState<PlanWorkOrderSummary | null>(null)
+  const [planDialogOpen, setPlanDialogOpen] = useState(false)
 
   const weekStart = useMemo(
     () => startOfWeek(anchor, { weekStartsOn: 1 }),
@@ -47,6 +52,7 @@ export function WorkAgendaBoard({ initialTechnicianId }: WorkAgendaBoardProps) {
   )
   const bounds = useMemo(() => getWeekBounds(anchor), [anchor])
   const today = useMemo(() => new Date(), [])
+  const todayKey = format(today, "yyyy-MM-dd")
 
   const loadAgenda = useCallback(async () => {
     setLoading(true)
@@ -78,6 +84,12 @@ export function WorkAgendaBoard({ initialTechnicianId }: WorkAgendaBoardProps) {
     loadAgenda()
   }, [loadAgenda])
 
+  useEffect(() => {
+    if (!selectedDay) {
+      setSelectedDay(todayKey)
+    }
+  }, [selectedDay, todayKey])
+
   const byDay = useMemo(
     () => groupAgendaByDay(scheduled, weekStart),
     [scheduled, weekStart],
@@ -85,6 +97,26 @@ export function WorkAgendaBoard({ initialTechnicianId }: WorkAgendaBoardProps) {
 
   const weekLabel = format(weekStart, "d MMM", { locale: es })
   const weekEndLabel = format(endOfWeek(weekStart, { weekStartsOn: 1 }), "d MMM yyyy", { locale: es })
+
+  const openPlanDialog = (wo: AgendaWorkOrder, defaultDate?: string) => {
+    setPlanningOrder({
+      id: wo.id,
+      order_id: wo.order_id,
+      description: wo.description,
+      priority: wo.priority,
+      status: wo.status,
+      planned_date: wo.planned_date,
+      assigned_to: wo.assigned_to,
+      asset_code: wo.asset_code,
+      asset_name: wo.asset_name,
+      origin: wo.origin,
+      technician_name: wo.technician_name,
+    })
+    if (defaultDate) {
+      setSelectedDay(defaultDate)
+    }
+    setPlanDialogOpen(true)
+  }
 
   const hojaHref =
     technicianId && technicianId !== "all"
@@ -138,7 +170,14 @@ export function WorkAgendaBoard({ initialTechnicianId }: WorkAgendaBoardProps) {
         <>
           <div className="grid grid-cols-1 md:grid-cols-7 gap-3">
             {[...byDay.entries()].map(([dayKey, items]) => (
-              <Card key={dayKey} className="min-h-[12rem]">
+              <Card
+                key={dayKey}
+                className={cn(
+                  "min-h-[12rem] cursor-pointer transition-shadow hover:shadow-md",
+                  selectedDay === dayKey && "ring-2 ring-primary",
+                )}
+                onClick={() => setSelectedDay(dayKey)}
+              >
                 <CardHeader className="py-3 px-3">
                   <CardTitle className="text-xs font-semibold capitalize">
                     {formatAgendaDayLabel(dayKey, today)}
@@ -149,13 +188,21 @@ export function WorkAgendaBoard({ initialTechnicianId }: WorkAgendaBoardProps) {
                     <p className="text-xs text-muted-foreground">Sin trabajos</p>
                   ) : (
                     items.map((wo) => (
-                      <AgendaCard key={wo.id} workOrder={wo} />
+                      <AgendaCard
+                        key={wo.id}
+                        workOrder={wo}
+                        onPlan={() => openPlanDialog(wo, dayKey)}
+                      />
                     ))
                   )}
                 </CardContent>
               </Card>
             ))}
           </div>
+
+          {selectedDay && (
+            <AgendaDayDetailPanel date={selectedDay} technicianId={technicianId} />
+          )}
 
           {unscheduled.length > 0 && (
             <Card>
@@ -167,13 +214,26 @@ export function WorkAgendaBoard({ initialTechnicianId }: WorkAgendaBoardProps) {
               </CardHeader>
               <CardContent className="space-y-2">
                 {unscheduled.map((wo) => (
-                  <AgendaCard key={wo.id} workOrder={wo} showScheduleHint />
+                  <AgendaCard
+                    key={wo.id}
+                    workOrder={wo}
+                    showScheduleHint
+                    onPlan={() => openPlanDialog(wo, selectedDay ?? todayKey)}
+                  />
                 ))}
               </CardContent>
             </Card>
           )}
         </>
       )}
+
+      <PlanWorkOrderDialog
+        open={planDialogOpen}
+        onOpenChange={setPlanDialogOpen}
+        workOrder={planningOrder}
+        defaultPlannedDate={selectedDay ?? todayKey}
+        onSaved={loadAgenda}
+      />
     </div>
   )
 }
@@ -181,9 +241,11 @@ export function WorkAgendaBoard({ initialTechnicianId }: WorkAgendaBoardProps) {
 function AgendaCard({
   workOrder: wo,
   showScheduleHint,
+  onPlan,
 }: {
   workOrder: AgendaWorkOrder
   showScheduleHint?: boolean
+  onPlan?: () => void
 }) {
   const priorityClass =
     wo.priority === "Alta"
@@ -193,35 +255,66 @@ function AgendaCard({
         : "border-border bg-muted/30"
 
   return (
-    <Link
-      href={`/ordenes/${wo.id}`}
+    <div
       className={cn(
-        "block rounded-md border p-2 text-xs transition-colors hover:bg-muted/50",
+        "rounded-md border p-2 text-xs transition-colors",
         priorityClass,
       )}
     >
-      <div className="flex items-start justify-between gap-1">
-        <span className="font-semibold">{wo.order_id}</span>
-        <Badge variant="outline" className="text-[10px] shrink-0">
-          {ORIGIN_LABELS[wo.origin]}
-        </Badge>
-      </div>
-      <p className="text-muted-foreground truncate mt-0.5">
-        {wo.asset_code ?? wo.asset_name ?? "Sin activo"}
-      </p>
-      <p className="line-clamp-2 mt-1">{wo.description}</p>
-      {wo.technician_name && (
-        <p className="text-muted-foreground mt-1 flex items-center gap-1">
-          <Wrench className="h-3 w-3" />
-          {wo.technician_name}
+      <button
+        type="button"
+        className="w-full text-left hover:opacity-90"
+        onClick={(e) => {
+          e.stopPropagation()
+          onPlan?.()
+        }}
+      >
+        <div className="flex items-start justify-between gap-1">
+          <span className="font-semibold">{wo.order_id}</span>
+          <Badge variant="outline" className="text-[10px] shrink-0">
+            {ORIGIN_LABELS[wo.origin]}
+          </Badge>
+        </div>
+        <p className="text-muted-foreground truncate mt-0.5">
+          {wo.asset_code ?? wo.asset_name ?? "Sin activo"}
         </p>
-      )}
-      {showScheduleHint && (
-        <p className="text-amber-700 mt-1 font-medium">Pendiente de fecha</p>
-      )}
-      {wo.hours_open != null && wo.origin === "incident" && wo.hours_open >= 3 && (
-        <p className="text-red-700 mt-1">{wo.hours_open}d abierto</p>
-      )}
-    </Link>
+        <p className="line-clamp-2 mt-1">{wo.description}</p>
+        {wo.technician_name && (
+          <p className="text-muted-foreground mt-1 flex items-center gap-1">
+            <Wrench className="h-3 w-3" />
+            {wo.technician_name}
+          </p>
+        )}
+        {showScheduleHint && (
+          <p className="text-amber-700 mt-1 font-medium">Pendiente de fecha</p>
+        )}
+        {wo.hours_open != null && wo.origin === "incident" && wo.hours_open >= 3 && (
+          <p className="text-red-700 mt-1">{wo.hours_open}d abierto</p>
+        )}
+      </button>
+      <div className="mt-2 flex items-center gap-2">
+        {onPlan && (
+          <Button
+            variant="secondary"
+            size="sm"
+            className="h-7 text-[11px] px-2"
+            onClick={(e) => {
+              e.stopPropagation()
+              onPlan()
+            }}
+          >
+            <CalendarPlus className="h-3 w-3 mr-1" />
+            Planificar
+          </Button>
+        )}
+        <Link
+          href={`/ordenes/${wo.id}`}
+          className="text-[11px] text-primary hover:underline"
+          onClick={(e) => e.stopPropagation()}
+        >
+          Ver OT
+        </Link>
+      </div>
+    </div>
   )
 }

--- a/components/compras/ComprasDesktopInfoDrawer.tsx
+++ b/components/compras/ComprasDesktopInfoDrawer.tsx
@@ -193,10 +193,10 @@ export function ComprasDesktopInfoDrawer({
                     )}
                   </div>
                 </div>
-                <Link href="/compras/cuentas-por-pagar" onClick={() => setOpen(false)}>
+                <Link href="/compras" onClick={() => setOpen(false)}>
                   <Button variant="outline" size="sm" className="shrink-0 text-sky-700 border-sky-200 hover:bg-sky-50 cursor-pointer">
                     <ExternalLink className="h-4 w-4 mr-1" />
-                    Ver Detalle
+                    Ver en OC
                   </Button>
                 </Link>
               </div>
@@ -255,38 +255,17 @@ export function ComprasDesktopInfoDrawer({
 
           {/* Secondary actions */}
           <div className="flex flex-col gap-2 pt-2">
-            {profile && canCreateOrders && (
-              <Link href="/compras/comprobantes" onClick={() => setOpen(false)}>
-                <Button variant="outline" className="w-full justify-start gap-2 cursor-pointer">
-                  <Receipt className="h-4 w-4" />
-                  Ver Comprobantes
-                </Button>
-              </Link>
-            )}
             {isAdmin && (
               <Link href="/compras/procurement" onClick={() => setOpen(false)}>
                 <Button variant="outline" className="w-full justify-start gap-2 bg-sky-50 border-sky-200 text-sky-800 hover:bg-sky-100 cursor-pointer">
                   <FileText className="h-4 w-4" />
-                  Compras post-aprobación
+                  Post-aprobación (panel OC)
                 </Button>
               </Link>
             )}
-            {isAdmin && (
-              <Link href="/compras/facturas" onClick={() => setOpen(false)}>
-                <Button variant="outline" className="w-full justify-start gap-2 cursor-pointer">
-                  <FileText className="h-4 w-4" />
-                  Facturas OC
-                </Button>
-              </Link>
-            )}
-            {isAdmin && (
-              <Link href="/compras/cuentas-por-pagar" onClick={() => setOpen(false)}>
-                <Button variant="outline" className="w-full justify-start gap-2 bg-orange-50 border-orange-200 text-orange-700 hover:bg-orange-100 cursor-pointer">
-                  <DollarSign className="h-4 w-4" />
-                  Cuentas por Pagar
-                </Button>
-              </Link>
-            )}
+            <p className="text-xs text-muted-foreground px-1">
+              Comprobantes, CFDI y pagos se gestionan desde el detalle de cada orden de compra.
+            </p>
           </div>
         </div>
       </SheetContent>

--- a/components/compras/ComprasMobileInfoDrawer.tsx
+++ b/components/compras/ComprasMobileInfoDrawer.tsx
@@ -165,10 +165,10 @@ export function ComprasMobileInfoDrawer({
                     )}
                   </div>
                 </div>
-                <Link href="/compras/cuentas-por-pagar" onClick={() => setOpen(false)}>
+                <Link href="/compras" onClick={() => setOpen(false)}>
                   <Button variant="outline" size="sm" className="shrink-0 min-h-[44px] text-sky-700 border-sky-200 hover:bg-sky-50 cursor-pointer">
                     <ExternalLink className="h-4 w-4 mr-1" />
-                    Ver Detalle
+                    Ver en OC
                   </Button>
                 </Link>
               </div>
@@ -195,38 +195,17 @@ export function ComprasMobileInfoDrawer({
 
           {/* Secondary actions */}
           <div className="flex flex-col gap-2 pt-2">
-            {profile && canCreateOrders && (
-              <Link href="/compras/comprobantes" onClick={() => setOpen(false)}>
-                <Button variant="outline" className="w-full min-h-[44px] justify-start gap-2 cursor-pointer">
-                  <Receipt className="h-4 w-4" />
-                  Ver Comprobantes
-                </Button>
-              </Link>
-            )}
             {isAdmin && (
               <Link href="/compras/procurement" onClick={() => setOpen(false)}>
                 <Button variant="outline" className="w-full min-h-[44px] justify-start gap-2 bg-sky-50 border-sky-200 text-sky-800 hover:bg-sky-100 cursor-pointer">
                   <FileText className="h-4 w-4" />
-                  Compras post-aprobación
+                  Post-aprobación (panel OC)
                 </Button>
               </Link>
             )}
-            {isAdmin && (
-              <Link href="/compras/facturas" onClick={() => setOpen(false)}>
-                <Button variant="outline" className="w-full min-h-[44px] justify-start gap-2 cursor-pointer">
-                  <FileText className="h-4 w-4" />
-                  Facturas OC
-                </Button>
-              </Link>
-            )}
-            {isAdmin && (
-              <Link href="/compras/cuentas-por-pagar" onClick={() => setOpen(false)}>
-                <Button variant="outline" className="w-full min-h-[44px] justify-start gap-2 bg-orange-50 border-orange-200 text-orange-700 hover:bg-orange-100 cursor-pointer">
-                  <DollarSign className="h-4 w-4" />
-                  Cuentas por Pagar
-                </Button>
-              </Link>
-            )}
+            <p className="text-xs text-muted-foreground px-1">
+              Comprobantes, CFDI y pagos se gestionan desde el detalle de cada orden de compra.
+            </p>
           </div>
         </div>
       </SheetContent>

--- a/components/compras/procurement/PoProcurementNavCard.tsx
+++ b/components/compras/procurement/PoProcurementNavCard.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import Link from "next/link"
+import { DollarSign, FileText, Receipt } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface PoProcurementNavCardProps {
+  purchaseOrderId: string
+  orderIdDisplay: string
+  showPostApproval?: boolean
+}
+
+/**
+ * Entry points for post-approval procurement from a single OC — avoids orphan sidebar nav.
+ */
+export function PoProcurementNavCard({
+  purchaseOrderId,
+  orderIdDisplay,
+  showPostApproval = true,
+}: PoProcurementNavCardProps) {
+  if (!showPostApproval) return null
+
+  return (
+    <Card className="rounded-2xl border border-border/60" id="po-procurement-nav">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold">Contabilidad y pagos</CardTitle>
+        <CardDescription className="text-xs">
+          Comprobantes, CFDI y cuentas por pagar de esta OC ({orderIdDisplay})
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        <Button variant="outline" size="sm" className="justify-start" asChild>
+          <a href="#po-comprobantes">
+            <Receipt className="mr-2 h-4 w-4 shrink-0" />
+            Comprobantes de compra
+          </a>
+        </Button>
+        <Button variant="outline" size="sm" className="justify-start" asChild>
+          <a href="#po-factura-cfdi">
+            <FileText className="mr-2 h-4 w-4 shrink-0" />
+            Factura proveedor (CFDI)
+          </a>
+        </Button>
+        <Button variant="outline" size="sm" className="justify-start" asChild>
+          <Link href={`/compras/cuentas-por-pagar?po=${purchaseOrderId}`}>
+            <DollarSign className="mr-2 h-4 w-4 shrink-0" />
+            Estado de pago (CxP)
+          </Link>
+        </Button>
+        <Button variant="ghost" size="sm" className="justify-start text-muted-foreground" asChild>
+          <Link href={`/compras/comprobantes?po=${purchaseOrderId}`}>
+            Ver todos los comprobantes filtrados
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/purchase-orders/AccountsPayableView.tsx
+++ b/components/purchase-orders/AccountsPayableView.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { useSearchParams } from "next/navigation"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -14,6 +15,7 @@ import { Separator } from "@/components/ui/separator"
 import { AlertTriangle, Calendar, CheckCircle, CreditCard, DollarSign, Receipt, Clock, Building2, Store, Wrench, Filter, RefreshCw } from "lucide-react"
 import { format } from "date-fns"
 import { es } from "date-fns/locale"
+import Link from "next/link"
 import { AccountsPayableItem, AccountsPayableResponse, PaymentStatus, PaymentMethod, MarkAsPaidRequest } from "@/types/purchase-orders"
 import { formatCurrency } from "@/lib/utils"
 import { toast } from "sonner"
@@ -193,6 +195,8 @@ function MarkAsPaidDialog({ item, onPaid }: MarkAsPaidDialogProps) {
 }
 
 export function AccountsPayableView() {
+  const searchParams = useSearchParams()
+  const poFilter = searchParams.get("po")
   const [data, setData] = useState<AccountsPayableResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [activeFilter, setActiveFilter] = useState<string>('all')
@@ -265,8 +269,22 @@ export function AccountsPayableView() {
     )
   }
 
+  const displayItems = poFilter
+    ? data.items.filter((item) => item.id === poFilter)
+    : data.items
+
   return (
     <div className="space-y-6">
+      {poFilter && (
+        <Card className="border-sky-200 bg-sky-50/50">
+          <CardContent className="p-4 text-sm text-sky-900">
+            Mostrando pagos de una orden de compra específica.{" "}
+            <Link href="/compras/cuentas-por-pagar" className="underline font-medium">
+              Ver todas las CxP
+            </Link>
+          </CardContent>
+        </Card>
+      )}
       {/* Header with Refresh Button */}
       <div className="flex items-center justify-end">
         <Button onClick={handleRefresh} disabled={refreshing} variant="outline">
@@ -348,7 +366,7 @@ export function AccountsPayableView() {
         </TabsList>
 
         <TabsContent value={activeFilter} className="space-y-4">
-          {data.items.length === 0 ? (
+          {displayItems.length === 0 ? (
             <Card>
               <CardContent className="p-6">
                 <p className="text-center text-muted-foreground">
@@ -358,7 +376,7 @@ export function AccountsPayableView() {
             </Card>
           ) : (
             <div className="space-y-4">
-              {data.items.map((item) => (
+              {displayItems.map((item) => (
                 <Card key={item.id} className="hover:shadow-md transition-shadow">
                   <CardContent className="p-6">
                     <div className="flex items-center justify-between">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -41,6 +41,10 @@ import {
   IdCard,
   Target,
   TrendingUp,
+  CalendarDays,
+  Layers,
+  CircleDot,
+  GitBranch,
 } from "lucide-react"
 import { reportsNavItemsForProfile } from '@/lib/reports/reports-catalog'
 import { UserNav } from "@/components/user-nav"
@@ -54,6 +58,21 @@ import {
   canAccessRHReportingNav,
   canManageUserAuthorizationClient,
 } from "@/lib/auth/client-authorization"
+
+/** Main OT list — excludes planning sub-routes with their own nav items. */
+function isOrdenesHubActive(pathname: string) {
+  if (pathname === "/ordenes") return true
+  if (!pathname.startsWith("/ordenes/")) return false
+  const excludedPrefixes = ["/ordenes/planificacion", "/ordenes/campanas", "/ordenes/agenda"]
+  return !excludedPrefixes.some((p) => pathname === p || pathname.startsWith(`${p}/`))
+}
+
+/** Compras hub — excludes comprobantes and cuentas-por-pagar siblings. */
+function isComprasHubActive(pathname: string) {
+  if (pathname === "/compras") return true
+  if (!pathname.startsWith("/compras/")) return false
+  return !pathname.startsWith("/compras/comprobantes") && !pathname.startsWith("/compras/cuentas-por-pagar")
+}
 
 interface SidebarProps extends React.HTMLAttributes<HTMLDivElement> {
   onLinkClick?: () => void
@@ -351,7 +370,7 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                   <CollapsibleContent className="space-y-1 mt-2 transition-all duration-200 ease-in-out motion-reduce:transition-none">
                     {ui.shouldShowInNavigation('purchases') && (
                       <Button
-                        variant={isPathActive("/compras") ? "secondary" : "ghost"}
+                        variant={isComprasHubActive(pathname) ? "secondary" : "ghost"}
                         className={cn("w-full justify-start pl-8", navItemClasses)}
                         asChild
                         onClick={handleLinkClick}
@@ -558,7 +577,7 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                     )}
                     {ui.shouldShowInNavigation('assets') && (
                       <Button
-                        variant={isPathActive("/activos") ? "secondary" : "ghost"}
+                        variant={isPathActive("/activos") && !isPathActive("/activos/llantas") ? "secondary" : "ghost"}
                         className={cn("w-full justify-start pl-8", navItemClasses)}
                         asChild
                         onClick={handleLinkClick}
@@ -567,6 +586,19 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                         <Link href="/activos">
                           <Package className="mr-2 h-4 w-4" />
                           Activos
+                        </Link>
+                      </Button>
+                    )}
+                    {ui.shouldShowInNavigation('assets') && (
+                      <Button
+                        variant={isPathActive("/activos/llantas") ? "secondary" : "ghost"}
+                        className={cn("w-full justify-start pl-8", navItemClasses)}
+                        asChild
+                        onClick={handleLinkClick}
+                      >
+                        <Link href="/activos/llantas">
+                          <CircleDot className="mr-2 h-4 w-4" />
+                          Llantas
                         </Link>
                       </Button>
                     )}
@@ -614,7 +646,7 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                     )}
                     {ui.shouldShowInNavigation('assets') && (
                       <Button
-                        variant={isPathActive("/activos") ? "secondary" : "ghost"}
+                        variant={isPathActive("/activos") && !isPathActive("/activos/llantas") ? "secondary" : "ghost"}
                         className={cn("w-full justify-start pl-8", navItemClasses)}
                         asChild
                         onClick={handleLinkClick}
@@ -623,6 +655,19 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                         <Link href="/activos">
                           <Package className="mr-2 h-4 w-4" />
                           Activos
+                        </Link>
+                      </Button>
+                    )}
+                    {ui.shouldShowInNavigation('assets') && (
+                      <Button
+                        variant={isPathActive("/activos/llantas") ? "secondary" : "ghost"}
+                        className={cn("w-full justify-start pl-8", navItemClasses)}
+                        asChild
+                        onClick={handleLinkClick}
+                      >
+                        <Link href="/activos/llantas">
+                          <CircleDot className="mr-2 h-4 w-4" />
+                          Llantas
                         </Link>
                       </Button>
                     )}
@@ -653,7 +698,7 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                   </CollapsibleTrigger>
                   <CollapsibleContent className="space-y-1 mt-2 transition-all duration-200 ease-in-out motion-reduce:transition-none">
                     <Button
-                      variant={isPathActive("/ordenes") ? "secondary" : "ghost"}
+                      variant={isOrdenesHubActive(pathname) ? "secondary" : "ghost"}
                       className={cn("w-full justify-start pl-8", navItemClasses)}
                       asChild
                       onClick={handleLinkClick}
@@ -665,8 +710,56 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                       </Link>
                     </Button>
                     {ui.shouldShowInNavigation('maintenance') && (
+                      <>
+                        <Button
+                          variant={isPathActive("/ordenes/agenda") ? "secondary" : "ghost"}
+                          className={cn("w-full justify-start pl-8", navItemClasses)}
+                          asChild
+                          onClick={handleLinkClick}
+                        >
+                          <Link href="/ordenes/agenda">
+                            <CalendarDays className="mr-2 h-4 w-4" />
+                            Agenda semanal
+                          </Link>
+                        </Button>
+                        <Button
+                          variant={pathname === "/ordenes/agenda/hoja" ? "secondary" : "ghost"}
+                          className={cn("w-full justify-start pl-8", navItemClasses)}
+                          asChild
+                          onClick={handleLinkClick}
+                        >
+                          <Link href="/ordenes/agenda/hoja">
+                            <FileText className="mr-2 h-4 w-4" />
+                            Orden del día
+                          </Link>
+                        </Button>
+                        <Button
+                          variant={isPathActive("/ordenes/planificacion") ? "secondary" : "ghost"}
+                          className={cn("w-full justify-start pl-8", navItemClasses)}
+                          asChild
+                          onClick={handleLinkClick}
+                        >
+                          <Link href="/ordenes/planificacion">
+                            <Target className="mr-2 h-4 w-4" />
+                            Planificación
+                          </Link>
+                        </Button>
+                        <Button
+                          variant={isPathActive("/ordenes/campanas") ? "secondary" : "ghost"}
+                          className={cn("w-full justify-start pl-8", navItemClasses)}
+                          asChild
+                          onClick={handleLinkClick}
+                        >
+                          <Link href="/ordenes/campanas">
+                            <Layers className="mr-2 h-4 w-4" />
+                            Campañas
+                          </Link>
+                        </Button>
+                      </>
+                    )}
+                    {ui.shouldShowInNavigation('maintenance') && (
                       <Button
-                        variant={isPathActive("/incidentes") ? "secondary" : "ghost"}
+                        variant={isPathActive("/incidentes") && !isPathActive("/incidentes/pipeline") ? "secondary" : "ghost"}
                         className={cn("w-full justify-start pl-8", navItemClasses)}
                         asChild
                         onClick={handleLinkClick}
@@ -674,6 +767,19 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                         <Link href="/incidentes">
                           <AlertTriangle className="mr-2 h-4 w-4" />
                           Incidentes
+                        </Link>
+                      </Button>
+                    )}
+                    {ui.shouldShowInNavigation('maintenance') && (
+                      <Button
+                        variant={isPathActive("/incidentes/pipeline") ? "secondary" : "ghost"}
+                        className={cn("w-full justify-start pl-8", navItemClasses)}
+                        asChild
+                        onClick={handleLinkClick}
+                      >
+                        <Link href="/incidentes/pipeline">
+                          <GitBranch className="mr-2 h-4 w-4" />
+                          Pipeline de incidencias
                         </Link>
                       </Button>
                     )}
@@ -759,7 +865,7 @@ export function Sidebar({ className, onLinkClick }: SidebarProps) {
                   <CollapsibleContent className="space-y-1 mt-2 transition-all duration-200 ease-in-out motion-reduce:transition-none">
                     {ui.shouldShowInNavigation('purchases') && (
                       <Button
-                        variant={isPathActive("/compras") ? "secondary" : "ghost"}
+                        variant={isComprasHubActive(pathname) ? "secondary" : "ghost"}
                         className={cn("w-full justify-start pl-8", navItemClasses)}
                         asChild
                         onClick={handleLinkClick}
@@ -1204,36 +1310,54 @@ function buildNavigationSections(
       equipmentItems.push({ href: "/modelos", icon: Settings, label: "Modelos", active: isPathActive("/modelos") })
     }
     if (ui.shouldShowInNavigation('assets')) {
-      equipmentItems.push({ href: "/activos", icon: Package, label: "Activos", active: isPathActive("/activos") })
+      equipmentItems.push({ href: "/activos", icon: Package, label: "Activos", active: isPathActive("/activos") && !isPathActive("/activos/llantas") })
+      equipmentItems.push({ href: "/activos/llantas", icon: CircleDot, label: "Llantas", active: isPathActive("/activos/llantas") })
     }
     if (equipmentItems.length > 0) {
       sections.push({
         id: "equipment",
         icon: Wrench,
         label: "Equipos",
-        active: isSectionActive(["/modelos", "/activos"]),
+        active: isSectionActive(["/modelos", "/activos", "/activos/llantas"]),
         items: equipmentItems,
       })
     }
   }
 
-  // Trabajos - work orders + incidentes (Incidentes relacionado con Órdenes de trabajo)
+  // Trabajos - work orders + incidentes + agenda planning
   if (ui.shouldShowInNavigation('work_orders') || ui.shouldShowInNavigation('maintenance')) {
     const trabajosItems: NavItem[] = []
     if (ui.shouldShowInNavigation('work_orders')) {
-      trabajosItems.push(
-        { href: "/ordenes", icon: Clock, label: "Órdenes de Trabajo", active: isPathActive("/ordenes") }
-      )
+      trabajosItems.push({
+        href: "/ordenes",
+        icon: Clock,
+        label: "Órdenes de Trabajo",
+        active: isOrdenesHubActive(pathname),
+      })
     }
     if (ui.shouldShowInNavigation('maintenance')) {
-      trabajosItems.push({ href: "/incidentes", icon: AlertTriangle, label: "Incidentes", active: isPathActive("/incidentes") })
+      trabajosItems.push(
+        { href: "/ordenes/agenda", icon: CalendarDays, label: "Agenda semanal", active: isPathActive("/ordenes/agenda") },
+        { href: "/ordenes/agenda/hoja", icon: FileText, label: "Orden del día", active: pathname === "/ordenes/agenda/hoja" },
+        { href: "/ordenes/planificacion", icon: Target, label: "Planificación", active: isPathActive("/ordenes/planificacion") },
+        { href: "/ordenes/campanas", icon: Layers, label: "Campañas", active: isPathActive("/ordenes/campanas") },
+        { href: "/incidentes", icon: AlertTriangle, label: "Incidentes", active: isPathActive("/incidentes") && !isPathActive("/incidentes/pipeline") },
+        { href: "/incidentes/pipeline", icon: GitBranch, label: "Pipeline de incidencias", active: isPathActive("/incidentes/pipeline") },
+      )
     }
     if (trabajosItems.length > 0) {
       sections.push({
         id: "trabajos",
         icon: Tool,
         label: "Trabajos",
-        active: isSectionActive(["/ordenes", "/incidentes"]),
+        active: isSectionActive([
+          "/ordenes",
+          "/ordenes/planificacion",
+          "/ordenes/campanas",
+          "/ordenes/agenda",
+          "/incidentes",
+          "/incidentes/pipeline",
+        ]),
         items: trabajosItems,
       })
     }
@@ -1263,7 +1387,12 @@ function buildNavigationSections(
   if (ui.shouldShowInNavigation('purchases') || ui.shouldShowInNavigation('inventory')) {
     const procurementItems: NavItem[] = []
     if (ui.shouldShowInNavigation('purchases')) {
-      procurementItems.push({ href: "/compras", icon: CreditCard, label: "Órdenes de Compra", active: isPathActive("/compras") })
+      procurementItems.push({
+        href: "/compras",
+        icon: CreditCard,
+        label: "Órdenes de Compra",
+        active: isComprasHubActive(pathname),
+      })
     }
     if (ui.shouldShowInNavigation('inventory')) {
       procurementItems.push({ href: "/inventario", icon: Boxes, label: "Inventario", active: isPathActive("/inventario") })

--- a/components/work-orders/WorkOrdersFilterBar.tsx
+++ b/components/work-orders/WorkOrdersFilterBar.tsx
@@ -45,6 +45,12 @@ const TYPE_OPTIONS = [
   { id: "corrective", label: "Correctivo" },
 ] as const
 
+const SCHEDULING_OPTIONS = [
+  { id: "all", label: "Toda programación" },
+  { id: "scheduled", label: "Con fecha programada" },
+  { id: "unscheduled", label: "Sin programar" },
+] as const
+
 const SORT_OPTIONS: { id: WorkOrderSortBy; label: string }[] = [
   { id: "default", label: "Por creación" },
   { id: "priority", label: "Por prioridad" },
@@ -323,6 +329,28 @@ function MobileFiltersContent({
           </SelectTrigger>
           <SelectContent>
             {ORIGIN_OPTIONS.map((o) => (
+              <SelectItem key={o.id} value={o.id}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div>
+        <Label className="text-sm font-medium text-slate-700">Programación</Label>
+        <Select
+          value={filters.schedulingFilter}
+          onValueChange={(v) =>
+            onFiltersChange({
+              schedulingFilter: v as WorkOrderFilters["schedulingFilter"],
+            })
+          }
+        >
+          <SelectTrigger className="mt-1">
+            <SelectValue placeholder="Toda programación" />
+          </SelectTrigger>
+          <SelectContent>
+            {SCHEDULING_OPTIONS.map((o) => (
               <SelectItem key={o.id} value={o.id}>
                 {o.label}
               </SelectItem>

--- a/components/work-orders/work-orders-list.tsx
+++ b/components/work-orders/work-orders-list.tsx
@@ -7,7 +7,7 @@ import { Badge, badgeVariants } from "@/components/ui/badge"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { User, AlertTriangle, ShoppingCart, Calendar, Package, Repeat, ArrowUpDown, ArrowUp, ArrowDown, Eye } from "lucide-react"
+import { User, AlertTriangle, ShoppingCart, Calendar, Package, Repeat, ArrowUpDown, ArrowUp, ArrowDown, Eye, CalendarDays, CalendarPlus } from "lucide-react"
 import { createClient } from "@/lib/supabase"
 import { useIsMobile } from "@/hooks/use-mobile"
 import Link from "next/link"
@@ -27,6 +27,11 @@ import type { WorkOrderSummaryMetrics } from "@/components/work-orders/WorkOrder
 import type { WorkOrderFilters, WorkOrderSortBy, WorkOrderSortDir } from "@/hooks/useWorkOrderFilters"
 import { cn } from "@/lib/utils"
 import { PullToRefresh } from "@/components/ui/pull-to-refresh"
+import { PlanWorkOrderDialog, type PlanWorkOrderSummary } from "@/components/agenda/plan-work-order-dialog"
+import { inferWorkOrderOrigin } from "@/lib/agenda/agenda-utils"
+import { format, parseISO } from "date-fns"
+import { es } from "date-fns/locale"
+import { isPendingStatus } from "@/lib/work-order-status-tabs"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -162,17 +167,28 @@ function getPurchaseOrderStatusClass(status: string) {
   }
 }
 
+function formatPlannedDate(value: string | null | undefined): string {
+  if (!value) return "Sin programar"
+  try {
+    return format(parseISO(value.slice(0, 10)), "d MMM yyyy", { locale: es })
+  } catch {
+    return value
+  }
+}
+
 // Mobile-optimized WorkOrder Card Component
 function WorkOrderCard({ 
   order, 
   getTechnicianName, 
   getPurchaseOrderStatus,
-  onDeleteOrder
+  onDeleteOrder,
+  onPlan,
 }: { 
   order: WorkOrderListRow
   getTechnicianName: (techId: string | null) => string
   getPurchaseOrderStatus: (poId: string | null) => string
   onDeleteOrder: (order: WorkOrderListRow) => void
+  onPlan?: (order: WorkOrderListRow) => void
 }) {
   const linkedPoIds = getLinkedPOIdsForWorkOrderRow(order)
   return (
@@ -275,10 +291,16 @@ function WorkOrderCard({
           })()}
         </div>
         
-        {/* Technician */}
+        {/* Technician + planned date */}
         <div className="flex items-center gap-2 text-sm">
           <User className="h-4 w-4 text-muted-foreground shrink-0" />
           <span className="truncate">{getTechnicianName(order.assigned_to)}</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <CalendarDays className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span className={cn(!order.planned_date && "text-amber-700 font-medium")}>
+            {formatPlannedDate(order.planned_date)}
+          </span>
         </div>
         
         {/* Creation date + recurrence tooltip */}
@@ -315,6 +337,17 @@ function WorkOrderCard({
               OC: {ocStatusSummaryForRow(order, getPurchaseOrderStatus)}
             </Badge>
           </div>
+        )}
+        {onPlan && order.status !== "Completada" && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={() => onPlan(order)}
+          >
+            <CalendarPlus className="h-4 w-4 mr-2" />
+            Programar
+          </Button>
         )}
       </CardContent>
     </Card>
@@ -362,6 +395,25 @@ export function WorkOrdersList() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [orderToDelete, setOrderToDelete] = useState<WorkOrderListRow | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
+  const [planningOrder, setPlanningOrder] = useState<PlanWorkOrderSummary | null>(null)
+  const [planDialogOpen, setPlanDialogOpen] = useState(false)
+
+  const openPlanDialog = (order: WorkOrderListRow) => {
+    setPlanningOrder({
+      id: order.id,
+      order_id: order.order_id ?? order.id,
+      description: order.description ?? "",
+      priority: order.priority ?? null,
+      status: order.status ?? "Pendiente",
+      planned_date: order.planned_date ?? null,
+      assigned_to: order.assigned_to ?? null,
+      asset_code: order.asset?.asset_id ?? null,
+      asset_name: order.asset?.name ?? null,
+      origin: inferWorkOrderOrigin(order),
+      technician_name: null,
+    })
+    setPlanDialogOpen(true)
+  }
 
   // Load work orders — single API call (server does parallel fetches, minimal payload)
   const loadWorkOrders = async () => {
@@ -454,6 +506,12 @@ export function WorkOrdersList() {
     return { pending, completed, recurrentes }
   }, [workOrders])
 
+  const unscheduledCount = useMemo(
+    () =>
+      workOrders.filter((o) => !o.planned_date && isPendingStatus(o.status)).length,
+    [workOrders],
+  )
+
   const handleRecurrentesClick = () => {
     if (filters.recurrentesOnly) {
       setFilters({ recurrentesOnly: false })
@@ -543,6 +601,27 @@ export function WorkOrdersList() {
       <PullToRefresh onRefresh={handlePullToRefresh} disabled={isLoading}>
         {/* Apple HIG: Content-first, deference, clarity. Single toolbar + unified segmented control. */}
         <div className="space-y-6">
+          {unscheduledCount > 0 && (
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3">
+              <p className="text-sm text-amber-900 flex items-center gap-2">
+                <CalendarDays className="h-4 w-4 shrink-0" />
+                {unscheduledCount} órdenes sin fecha programada — planifique desde la agenda o aquí mismo.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="bg-white"
+                  onClick={() => setFilters({ schedulingFilter: "unscheduled", tab: "all" })}
+                >
+                  Ver sin programar
+                </Button>
+                <Button size="sm" asChild>
+                  <Link href="/ordenes/agenda">Ir a agenda</Link>
+                </Button>
+              </div>
+            </div>
+          )}
           {/* Toolbar: Search + Filters. Progressive disclosure per HIG. */}
           <div className="flex flex-col gap-4">
             <WorkOrdersFilterBar
@@ -623,6 +702,7 @@ export function WorkOrdersList() {
                     onDeleteOrder={handleDeleteWorkOrder}
                     hasActiveFilters={hasActiveFilters}
                     onClearFilters={clearAllFilters}
+                    onPlan={openPlanDialog}
                   />
                 ) : (
                   <DesktopView
@@ -636,6 +716,7 @@ export function WorkOrdersList() {
                     onClearFilters={clearAllFilters}
                     filters={filters}
                     onSortChange={setFilters}
+                    onPlan={openPlanDialog}
                   />
                 )}
               </TabsContent>
@@ -651,6 +732,7 @@ export function WorkOrdersList() {
                     onDeleteOrder={handleDeleteWorkOrder}
                     hasActiveFilters={hasActiveFilters}
                     onClearFilters={clearAllFilters}
+                    onPlan={openPlanDialog}
                   />
                 ) : (
                   <DesktopView 
@@ -664,6 +746,7 @@ export function WorkOrdersList() {
                     onClearFilters={clearAllFilters}
                     filters={filters}
                     onSortChange={setFilters}
+                    onPlan={openPlanDialog}
                   />
                 )}
               </TabsContent>
@@ -679,6 +762,7 @@ export function WorkOrdersList() {
                     onDeleteOrder={handleDeleteWorkOrder}
                     hasActiveFilters={hasActiveFilters}
                     onClearFilters={clearAllFilters}
+                    onPlan={openPlanDialog}
                   />
                 ) : (
                   <DesktopView 
@@ -692,6 +776,7 @@ export function WorkOrdersList() {
                     onClearFilters={clearAllFilters}
                     filters={filters}
                     onSortChange={setFilters}
+                    onPlan={openPlanDialog}
                   />
                 )}
               </TabsContent>
@@ -703,6 +788,13 @@ export function WorkOrdersList() {
           </div>
         </div>
       </PullToRefresh>
+
+      <PlanWorkOrderDialog
+        open={planDialogOpen}
+        onOpenChange={setPlanDialogOpen}
+        workOrder={planningOrder}
+        onSaved={loadWorkOrders}
+      />
 
       {/* Delete confirmation dialog */}
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
@@ -751,6 +843,7 @@ function MobileView({
   onDeleteOrder,
   hasActiveFilters,
   onClearFilters,
+  onPlan,
 }: {
   orders: WorkOrderListRow[]
   groupedOrders: GroupedOrdersItem[] | null
@@ -760,6 +853,7 @@ function MobileView({
   onDeleteOrder: (order: WorkOrderListRow) => void
   hasActiveFilters?: boolean
   onClearFilters?: () => void
+  onPlan?: (order: WorkOrderListRow) => void
 }) {
   if (isLoading) {
     return (
@@ -822,6 +916,7 @@ function MobileView({
                   getTechnicianName={getTechnicianName}
                   getPurchaseOrderStatus={getPurchaseOrderStatus}
                   onDeleteOrder={onDeleteOrder}
+                  onPlan={onPlan}
                 />
               ))}
             </div>
@@ -842,6 +937,7 @@ function MobileView({
           getTechnicianName={getTechnicianName}
           getPurchaseOrderStatus={getPurchaseOrderStatus}
           onDeleteOrder={onDeleteOrder}
+          onPlan={onPlan}
         />
       ))}
     </div>
@@ -904,6 +1000,7 @@ function DesktopView({
   onClearFilters,
   filters,
   onSortChange,
+  onPlan,
 }: {
   orders: WorkOrderListRow[]
   groupedOrders: GroupedOrdersItem[] | null
@@ -915,6 +1012,7 @@ function DesktopView({
   onClearFilters?: () => void
   filters: WorkOrderFilters
   onSortChange: (patch: Partial<WorkOrderFilters>) => void
+  onPlan?: (order: WorkOrderListRow) => void
 }) {
   const router = useRouter()
   if (isLoading) {
@@ -963,6 +1061,7 @@ function DesktopView({
             <TableHead className="w-[88px] py-3 px-3 text-[13px] font-semibold text-muted-foreground shrink-0">Tipo</TableHead>
             <SortableTableHead label="Prioridad" sortKey="priority" filters={filters} onSortChange={onSortChange} className="w-[82px]" />
             <TableHead className="w-[95px] py-3 px-3 text-[13px] font-semibold text-muted-foreground shrink-0">Estado</TableHead>
+            <TableHead className="w-[100px] py-3 px-3 text-[13px] font-semibold text-muted-foreground shrink-0">Programada</TableHead>
             <TableHead className="w-[110px] py-3 px-3 text-[13px] font-semibold text-muted-foreground shrink-0">Origen</TableHead>
             <TableHead className="w-[95px] py-3 px-3 text-[13px] font-semibold text-muted-foreground shrink-0">Recurr.</TableHead>
             <SortableTableHead label="Creado" sortKey="created" filters={filters} onSortChange={onSortChange} className="w-[88px]" />
@@ -1019,6 +1118,11 @@ function DesktopView({
                   {order.status || 'N/A'}
                 </Badge>
               </TableCell>
+              <TableCell className="py-3 px-3 text-xs" onClick={(e) => e.stopPropagation()}>
+                <span className={cn(!order.planned_date && "text-amber-700 font-medium")}>
+                  {formatPlannedDate(order.planned_date)}
+                </span>
+              </TableCell>
               <TableCell className="py-3 px-3" onClick={(e) => e.stopPropagation()}>
                 {(() => {
                   const origin = getOriginBadge(order)
@@ -1068,29 +1172,42 @@ function DesktopView({
                 })()}
               </TableCell>
               <TableCell className="py-3 px-3 text-xs" onClick={(e) => e.stopPropagation()}>
-                <div className="flex items-center gap-2">
-                  <span className="truncate max-w-[80px]" title={getTechnicianName(order.assigned_to)}>{getTechnicianName(order.assigned_to)}</span>
-                  {(() => {
-                    const poIdsRow = getLinkedPOIdsForWorkOrderRow(order)
-                    if (poIdsRow.length === 0) return null
-                    return (
-                      <span className="flex items-center gap-0.5 shrink-0">
-                        {poIdsRow.slice(0, 2).map((poId) => (
-                          <Link
-                            key={poId}
-                            href={`/compras/${poId}`}
-                            title="Ver OC"
-                            className="text-muted-foreground hover:text-foreground"
-                          >
-                            <ShoppingCart className="h-4 w-4" />
-                          </Link>
-                        ))}
-                        {poIdsRow.length > 2 ? (
-                          <span className="text-[10px] text-muted-foreground">+{poIdsRow.length - 2}</span>
-                        ) : null}
-                      </span>
-                    )
-                  })()}
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate max-w-[80px]" title={getTechnicianName(order.assigned_to)}>{getTechnicianName(order.assigned_to)}</span>
+                    {(() => {
+                      const poIdsRow = getLinkedPOIdsForWorkOrderRow(order)
+                      if (poIdsRow.length === 0) return null
+                      return (
+                        <span className="flex items-center gap-0.5 shrink-0">
+                          {poIdsRow.slice(0, 2).map((poId) => (
+                            <Link
+                              key={poId}
+                              href={`/compras/${poId}`}
+                              title="Ver OC"
+                              className="text-muted-foreground hover:text-foreground"
+                            >
+                              <ShoppingCart className="h-4 w-4" />
+                            </Link>
+                          ))}
+                          {poIdsRow.length > 2 ? (
+                            <span className="text-[10px] text-muted-foreground">+{poIdsRow.length - 2}</span>
+                          ) : null}
+                        </span>
+                      )
+                    })()}
+                  </div>
+                  {onPlan && order.status !== "Completada" && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-xs justify-start"
+                      onClick={() => onPlan(order)}
+                    >
+                      <CalendarPlus className="h-3.5 w-3.5 mr-1" />
+                      Programar
+                    </Button>
+                  )}
                 </div>
               </TableCell>
             </TableRow>

--- a/docs/superpowers/specs/2026-06-16-agenda-planning-v2-design.md
+++ b/docs/superpowers/specs/2026-06-16-agenda-planning-v2-design.md
@@ -1,0 +1,167 @@
+# Agenda Planning v2 — Design Spec
+
+**Date:** 2026-06-16  
+**Status:** Implemented  
+**Routes:** `/ordenes/agenda` (coordinador), `/ordenes/agenda/hoja` (mecánico)
+
+## Problem
+
+Coordinadores planifican la semana de mantenimiento sin visibilidad de:
+
+1. Si los insumos del día están disponibles en inventario.
+2. Qué producción de concreto está programada en las plantas donde operan los activos de la agenda.
+
+Los mecánicos necesitan una hoja simple — “orden del día” — con sus OTs, insumos por OT, y contexto de producción/remisiones de su unidad.
+
+## Solution Overview
+
+| Actor | Vista | Datos |
+|-------|-------|-------|
+| Coordinador | Agenda semanal + panel del día | Kit consolidado + pedidos Cotizador por planta |
+| Mecánico | Hoja imprimible | OTs del día + insumos + producción/remisiones |
+
+## APIs
+
+### `GET /api/integrations/cotizador/orders`
+
+**Auth:** required  
+**Query:** `from`, `to` (YYYY-MM-DD), `plantIds` (comma-separated MantenPro or Cotizador UUIDs), optional `include_pump=true`
+
+**Source:** Cotizador `orders` + `order_items` + `plants` + `clients`
+
+**Filters:**
+
+- `delivery_date` between `from` and `to`
+- `order_status IN ('created', 'validated')`
+- Optional plant filter (MantenPro IDs mapped via plant `code`)
+
+**Pump handling:**
+
+- Lines with `product_type` matching `/pump|bombeo|bomba/i` are flagged `is_pump_only: true`
+- Pump-only lines excluded by default
+- Orders whose items are exclusively pump service are excluded entirely
+
+**Response fields per line:** `order_number`, `delivery_date`, `delivery_time`, `construction_site`, `client_name`, `plant_id`, `plant_name`, `product_type`, `volume`, `concrete_volume_delivered`, `order_status`, `order_id`, `is_pump_only`
+
+### `GET /api/work-orders/agenda/daily-kit`
+
+**Auth:** required  
+**Query:** `date` (required), `technicianId` (optional)
+
+**Sources:**
+
+- `work_orders` scheduled on `date` with active statuses
+- `required_parts` JSONB on each WO
+- `required_tasks[].parts` from preventive plans
+
+**Inventory:** `StockService.checkMultiplePartsAvailability` per asset plant
+
+**Response:**
+
+- `kit[]` — consolidated parts with `sufficient` flags
+- `by_work_order[]` — per-OT breakdown
+- `plant_ids[]` — for Cotizador order lookup
+- `summary` — counts (total, sufficient, insufficient, unknown)
+
+## UI
+
+### Coordinador — `work-agenda-board.tsx`
+
+- Week grid with selectable day (ring highlight)
+- `AgendaDayDetailPanel` below grid:
+  - Kit de insumos del día (stock badges)
+  - Producción del día (Cotizador orders filtered by plants from scheduled assets)
+  - “Imprimir kit del día”
+
+### Mecánico — `mechanic-work-sheet.tsx`
+
+- Defaults: `from=to=today`, `technician=logged-in profile.id`
+- Per-day sections with OT table
+- Insumos listed under each OT
+- Plant production summary + remisiones per unit (`/api/integrations/cotizador/remisiones`)
+- Print-friendly layout preserved
+
+## Shared Libraries
+
+| Module | Purpose |
+|--------|---------|
+| `lib/agenda/cotizador-plant-map.ts` | MantenPro ↔ Cotizador plant mapping |
+| `lib/agenda/cotizador-orders.ts` | Pump detection + order flattening |
+| `lib/agenda/aggregate-daily-kit.ts` | Parts extraction + consolidation |
+
+## Environment
+
+Requires `COTIZADOR_SUPABASE_URL` and `COTIZADOR_SUPABASE_SERVICE_ROLE_KEY` for production data. APIs return empty arrays with `configured: false` when unset.
+
+## Manual Test Plan
+
+1. Log in as coordinador → `/ordenes/agenda`
+2. Select a day with scheduled WOs → verify kit table and stock badges
+3. Verify producción table (or “no configurada” message without Cotizador env)
+4. Click “Imprimir kit del día”
+5. Open hoja de trabajo → defaults to today + current user
+6. Verify insumos under each OT and remisiones when asset has deliveries
+7. Print preview on hoja
+
+## Known Limitations
+
+- Parts without `part_id` show “Sin catálogo” — no stock check
+- Cross-plant duplicate parts use best available stock across plants (not reservation-aware)
+- `concrete_volume_delivered` depends on Cotizador `order_items` column presence
+
+## Navigation & Workflows (2026-06-16)
+
+### Sidebar — Trabajos
+
+| Ruta | Etiqueta | Rol típico |
+|------|----------|------------|
+| `/ordenes` | Órdenes de Trabajo | Coordinador, gerencia |
+| `/ordenes/agenda` | Agenda semanal | Coordinador |
+| `/ordenes/agenda/hoja` | Orden del día | Mecánico |
+| `/ordenes/planificacion` | Planificación | Coordinador |
+| `/ordenes/campanas` | Campañas | Coordinador |
+| `/incidentes` | Incidentes | Mantenimiento |
+| `/incidentes/pipeline` | Pipeline de incidencias | Coordinador |
+
+Otros módulos recientes en sidebar: **Llantas** (`/activos/llantas`). Nómina / centro de mando: **Reportes → Centro de mando** (`/reportes/gerencial/analisis-costos`).
+
+### Planificación rápida (modal)
+
+`PlanWorkOrderDialog` — desde agenda (tarjetas sin programar o del día) o lista `/ordenes` (acción **Programar**):
+
+- Resumen OT (número, activo, descripción)
+- `planned_date`, `assigned_to`, `status`, `priority`
+- `PATCH /api/work-orders/[id]/schedule`
+
+### Lista de OTs
+
+- Banner **Sin programar** con enlace a agenda
+- Filtro **Programación**: con fecha / sin programar
+- Columna **Programada**
+
+### Flujo mecánico (hoja)
+
+En `/ordenes/agenda/hoja` (no impresión):
+
+- **Iniciar** → `PATCH /api/work-orders/[id]/status` (`En ejecución`)
+- **Completar** → `MechanicCompleteDialog` (modal de campo):
+  - Tareas requeridas (checkbox obligatorio si existen)
+  - Repuestos con cantidad usada (desde `required_parts` o ítems de OC)
+  - Lectura horas/km para preventivos con plan
+  - Horas de trabajo + notas
+  - Evidencia fotográfica opcional (`EvidenceUpload`, contexto `completion`)
+  - Validación alineada con `POST /api/maintenance/work-completions`
+- **Formulario completo** → `/ordenes/[id]/completar` (gastos adicionales, ajuste OC, absorción preventiva avanzada)
+
+### Compras — navegación post-aprobación (2026-06-16)
+
+**Decisión:** CFDI, comprobantes y CxP no son entradas primarias del sidebar. El flujo principal es **desde cada OC** (`/compras/[id]`).
+
+| Acceso | Dónde |
+|--------|--------|
+| Sidebar Compras | Solo **Órdenes de Compra** (+ inventario, diesel, proveedores) |
+| Detalle OC | `PoProcurementNavCard`: anclas `#po-comprobantes`, `#po-factura-cfdi`, enlace CxP `?po=` |
+| Rutas profundas | `/compras/comprobantes?po=`, `/compras/cuentas-por-pagar?po=` (sin nav lateral) |
+| Panel global | `/compras/procurement` para coordinación administrativa |
+
+Se eliminaron del sidebar: **Comprobantes (CFDI)** y **Cuentas por pagar** como ítems hermanos de Órdenes de Compra.

--- a/hooks/useWorkOrderFilters.ts
+++ b/hooks/useWorkOrderFilters.ts
@@ -24,6 +24,7 @@ export interface WorkOrderFilters {
   groupByAsset: boolean
   sortBy: WorkOrderSortBy
   sortDir: WorkOrderSortDir
+  schedulingFilter: "all" | "scheduled" | "unscheduled"
 }
 
 const DEFAULT_FILTERS: WorkOrderFilters = {
@@ -40,6 +41,7 @@ const DEFAULT_FILTERS: WorkOrderFilters = {
   groupByAsset: false,
   sortBy: "default",
   sortDir: "desc",
+  schedulingFilter: "all",
 }
 
 /** Work order shape needed for filtering (extended with origin/recurrence) */
@@ -131,6 +133,14 @@ export function applyWorkOrderFilters<T extends WorkOrderForFilter>(
       (o) =>
         (o.escalation_count != null && o.escalation_count > 0) ||
         (o.related_issues_count != null && o.related_issues_count > 1)
+    )
+  }
+
+  if (filters.schedulingFilter === "scheduled") {
+    result = result.filter((o) => !!o.planned_date && o.status !== "Completada")
+  } else if (filters.schedulingFilter === "unscheduled") {
+    result = result.filter(
+      (o) => !o.planned_date && o.status !== "Completada" && isPendingStatus(o.status),
     )
   }
 
@@ -393,6 +403,7 @@ export function useWorkOrderFilters() {
     !isTypeAll ||
     !isOriginAll ||
     filters.recurrentesOnly ||
+    filters.schedulingFilter !== "all" ||
     !!filters.fromDate ||
     !!filters.toDate ||
     filters.groupByAsset
@@ -403,6 +414,7 @@ export function useWorkOrderFilters() {
     !isTypeAll,
     !isOriginAll,
     filters.recurrentesOnly,
+    filters.schedulingFilter !== "all",
     filters.fromDate || filters.toDate,
     filters.groupByAsset,
   ].filter(Boolean).length

--- a/lib/agenda/agenda-auth.test.ts
+++ b/lib/agenda/agenda-auth.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  canAccessAgendaIntegrations,
+  canQuickUpdateWorkOrderStatus,
+  canViewCotizadorPlantMapping,
+} from "./agenda-auth"
+
+test("canQuickUpdateWorkOrderStatus allows coordinators and assigned mechanics", () => {
+  assert.equal(canQuickUpdateWorkOrderStatus("COORDINADOR_MANTENIMIENTO", "u1", "u2"), true)
+  assert.equal(canQuickUpdateWorkOrderStatus("MECANICO", "u1", "u1"), true)
+  assert.equal(canQuickUpdateWorkOrderStatus("MECANICO", "u1", "u2"), false)
+})
+
+test("canAccessAgendaIntegrations covers planning and mechanic roles", () => {
+  assert.equal(canAccessAgendaIntegrations("COORDINADOR_MANTENIMIENTO"), true)
+  assert.equal(canAccessAgendaIntegrations("MECANICO"), true)
+  assert.equal(canAccessAgendaIntegrations("VISUALIZADOR"), false)
+})
+
+test("plant mapping is restricted to global admin", () => {
+  assert.equal(canViewCotizadorPlantMapping("GERENCIA_GENERAL"), true)
+  assert.equal(canViewCotizadorPlantMapping("COORDINADOR_MANTENIMIENTO"), false)
+})

--- a/lib/agenda/agenda-auth.ts
+++ b/lib/agenda/agenda-auth.ts
@@ -1,0 +1,39 @@
+/** Roles that plan or oversee the maintenance agenda (coordinators, managers). */
+export const AGENDA_PLANNING_ROLES = [
+  "GERENCIA_GENERAL",
+  "GERENTE_MANTENIMIENTO",
+  "JEFE_UNIDAD_NEGOCIO",
+  "JEFE_PLANTA",
+  "COORDINADOR_MANTENIMIENTO",
+  "ENCARGADO_MANTENIMIENTO",
+] as const
+
+/** Roles that consume agenda APIs for field execution. */
+export const AGENDA_MECHANIC_ROLES = ["MECANICO"] as const
+
+export const AGENDA_INTEGRATION_ROLES = [
+  ...AGENDA_PLANNING_ROLES,
+  ...AGENDA_MECHANIC_ROLES,
+] as const
+
+export function isAgendaPlanningRole(role: string): boolean {
+  return (AGENDA_PLANNING_ROLES as readonly string[]).includes(role)
+}
+
+export function canAccessAgendaIntegrations(role: string): boolean {
+  return (AGENDA_INTEGRATION_ROLES as readonly string[]).includes(role)
+}
+
+export function canQuickUpdateWorkOrderStatus(
+  role: string,
+  userId: string,
+  assignedTo: string | null,
+): boolean {
+  if (isAgendaPlanningRole(role)) return true
+  if (role === "MECANICO") return assignedTo === userId
+  return false
+}
+
+export function canViewCotizadorPlantMapping(role: string): boolean {
+  return role === "GERENCIA_GENERAL"
+}

--- a/lib/agenda/agenda-utils.ts
+++ b/lib/agenda/agenda-utils.ts
@@ -8,6 +8,15 @@ import {
 } from "date-fns"
 import { es } from "date-fns/locale"
 
+/** Statuses included on agenda board, mechanic sheet, and daily-kit APIs. */
+export const AGENDA_ACTIVE_STATUSES = [
+  "Pendiente",
+  "Programada",
+  "Esperando repuestos",
+  "En ejecución",
+  "En Progreso",
+] as const
+
 export interface AgendaWorkOrder {
   id: string
   order_id: string

--- a/lib/agenda/aggregate-daily-kit.test.ts
+++ b/lib/agenda/aggregate-daily-kit.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  consolidateKitLines,
+  plantPartAvailabilityKey,
+} from "./aggregate-daily-kit"
+
+function availability(partId: string, total: number) {
+  return {
+    part_id: partId,
+    part_number: partId,
+    part_name: partId,
+    required_quantity: 0,
+    total_available: total,
+    sufficient: total > 0,
+    available_by_warehouse: [],
+  }
+}
+
+test("consolidateKitLines evaluates sufficiency per plant, not max across plants", () => {
+  const availabilityMap = new Map([
+    [plantPartAvailabilityKey("plant-a", "p1"), availability("p1", 5)],
+    [plantPartAvailabilityKey("plant-b", "p1"), availability("p1", 20)],
+  ])
+
+  const kit = consolidateKitLines(
+    [
+      {
+        part_id: "p1",
+        plant_id: "plant-a",
+        name: "Filtro",
+        part_number: "F-1",
+        quantity: 10,
+      },
+      {
+        part_id: "p1",
+        plant_id: "plant-b",
+        name: "Filtro",
+        part_number: "F-1",
+        quantity: 10,
+      },
+    ],
+    availabilityMap,
+  )
+
+  assert.equal(kit.length, 2)
+  const plantA = kit.find((line) => line.key.includes("plant-a"))
+  const plantB = kit.find((line) => line.key.includes("plant-b"))
+  assert.equal(plantA?.sufficient, false)
+  assert.equal(plantA?.total_available, 5)
+  assert.equal(plantB?.sufficient, true)
+  assert.equal(plantB?.total_available, 20)
+})
+
+test("consolidateKitLines sums quantities within the same plant", () => {
+  const availabilityMap = new Map([
+    [plantPartAvailabilityKey("plant-a", "p1"), availability("p1", 8)],
+  ])
+
+  const kit = consolidateKitLines(
+    [
+      { part_id: "p1", plant_id: "plant-a", name: "Filtro", quantity: 3 },
+      { part_id: "p1", plant_id: "plant-a", name: "Filtro", quantity: 4 },
+    ],
+    availabilityMap,
+  )
+
+  assert.equal(kit.length, 1)
+  assert.equal(kit[0]?.required_quantity, 7)
+  assert.equal(kit[0]?.sufficient, true)
+})

--- a/lib/agenda/aggregate-daily-kit.ts
+++ b/lib/agenda/aggregate-daily-kit.ts
@@ -5,8 +5,24 @@ export type RawPartLine = {
   part_number?: string | null
   name?: string | null
   quantity?: number | null
+  plant_id?: string | null
   source_work_order_id?: string
   source_order_id?: string
+}
+
+export function plantPartAvailabilityKey(plantId: string, partId: string): string {
+  return `${plantId}:${partId}`
+}
+
+function lookupPartAvailability(
+  line: RawPartLine,
+  availabilityMap: Map<string, PartAvailability>,
+): PartAvailability | undefined {
+  if (!line.part_id) return undefined
+  if (line.plant_id) {
+    return availabilityMap.get(plantPartAvailabilityKey(line.plant_id, line.part_id))
+  }
+  return availabilityMap.get(line.part_id)
 }
 
 export type ConsolidatedKitLine = {
@@ -45,13 +61,17 @@ function parseJsonArray<T>(value: unknown): T[] {
 }
 
 function partKey(part: RawPartLine): string {
-  if (part.part_id) return `id:${part.part_id}`
+  const plantPrefix = part.plant_id ? `plant:${part.plant_id}:` : ""
+  if (part.part_id) return `${plantPrefix}id:${part.part_id}`
   const num = (part.part_number ?? "").trim().toUpperCase()
   const name = (part.name ?? "").trim().toUpperCase()
-  return `manual:${num}|${name}`
+  return `${plantPrefix}manual:${num}|${name}`
 }
 
-export function extractPartsFromWorkOrder(wo: WorkOrderPartsSource): RawPartLine[] {
+export function extractPartsFromWorkOrder(
+  wo: WorkOrderPartsSource,
+  plantId?: string | null,
+): RawPartLine[] {
   const lines: RawPartLine[] = []
 
   for (const part of parseJsonArray<RawPartLine>(wo.required_parts)) {
@@ -60,6 +80,7 @@ export function extractPartsFromWorkOrder(wo: WorkOrderPartsSource): RawPartLine
     lines.push({
       ...part,
       quantity: qty > 0 ? qty : 1,
+      plant_id: plantId ?? part.plant_id ?? null,
       source_work_order_id: wo.id,
       source_order_id: wo.order_id,
     })
@@ -72,6 +93,7 @@ export function extractPartsFromWorkOrder(wo: WorkOrderPartsSource): RawPartLine
       lines.push({
         ...part,
         quantity: qty > 0 ? qty : 1,
+        plant_id: plantId ?? part.plant_id ?? null,
         source_work_order_id: wo.id,
         source_order_id: wo.order_id,
       })
@@ -103,7 +125,7 @@ export function consolidateKitLines(
     }
 
     const partId = line.part_id ?? null
-    const availability = partId ? availabilityByPartId.get(partId) : undefined
+    const availability = lookupPartAvailability(line, availabilityByPartId)
 
     map.set(key, {
       key,

--- a/lib/agenda/aggregate-daily-kit.ts
+++ b/lib/agenda/aggregate-daily-kit.ts
@@ -1,0 +1,142 @@
+import type { PartAvailability } from "@/lib/services/stock-service"
+
+export type RawPartLine = {
+  part_id?: string | null
+  part_number?: string | null
+  name?: string | null
+  quantity?: number | null
+  source_work_order_id?: string
+  source_order_id?: string
+}
+
+export type ConsolidatedKitLine = {
+  key: string
+  part_id: string | null
+  part_number: string
+  name: string
+  required_quantity: number
+  work_order_ids: string[]
+  order_ids: string[]
+  total_available: number | null
+  sufficient: boolean | null
+  available_by_warehouse: PartAvailability["available_by_warehouse"]
+}
+
+type WorkOrderPartsSource = {
+  id: string
+  order_id: string
+  asset_id: string | null
+  required_parts: unknown
+  required_tasks: unknown
+}
+
+function parseJsonArray<T>(value: unknown): T[] {
+  if (!value) return []
+  if (Array.isArray(value)) return value as T[]
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value)
+      return Array.isArray(parsed) ? (parsed as T[]) : []
+    } catch {
+      return []
+    }
+  }
+  return []
+}
+
+function partKey(part: RawPartLine): string {
+  if (part.part_id) return `id:${part.part_id}`
+  const num = (part.part_number ?? "").trim().toUpperCase()
+  const name = (part.name ?? "").trim().toUpperCase()
+  return `manual:${num}|${name}`
+}
+
+export function extractPartsFromWorkOrder(wo: WorkOrderPartsSource): RawPartLine[] {
+  const lines: RawPartLine[] = []
+
+  for (const part of parseJsonArray<RawPartLine>(wo.required_parts)) {
+    const qty = Number(part.quantity ?? 0)
+    if (qty <= 0 && !part.name && !part.part_number && !part.part_id) continue
+    lines.push({
+      ...part,
+      quantity: qty > 0 ? qty : 1,
+      source_work_order_id: wo.id,
+      source_order_id: wo.order_id,
+    })
+  }
+
+  for (const task of parseJsonArray<{ parts?: RawPartLine[] }>(wo.required_tasks)) {
+    for (const part of task.parts ?? []) {
+      const qty = Number(part.quantity ?? 0)
+      if (qty <= 0 && !part.name && !part.part_number && !part.part_id) continue
+      lines.push({
+        ...part,
+        quantity: qty > 0 ? qty : 1,
+        source_work_order_id: wo.id,
+        source_order_id: wo.order_id,
+      })
+    }
+  }
+
+  return lines
+}
+
+export function consolidateKitLines(
+  lines: RawPartLine[],
+  availabilityByPartId: Map<string, PartAvailability>,
+): ConsolidatedKitLine[] {
+  const map = new Map<string, ConsolidatedKitLine>()
+
+  for (const line of lines) {
+    const key = partKey(line)
+    const qty = Number(line.quantity ?? 0)
+    const existing = map.get(key)
+    if (existing) {
+      existing.required_quantity += qty
+      if (line.source_work_order_id && !existing.work_order_ids.includes(line.source_work_order_id)) {
+        existing.work_order_ids.push(line.source_work_order_id)
+      }
+      if (line.source_order_id && !existing.order_ids.includes(line.source_order_id)) {
+        existing.order_ids.push(line.source_order_id)
+      }
+      continue
+    }
+
+    const partId = line.part_id ?? null
+    const availability = partId ? availabilityByPartId.get(partId) : undefined
+
+    map.set(key, {
+      key,
+      part_id: partId,
+      part_number: line.part_number ?? "",
+      name: line.name ?? "Sin nombre",
+      required_quantity: qty,
+      work_order_ids: line.source_work_order_id ? [line.source_work_order_id] : [],
+      order_ids: line.source_order_id ? [line.source_order_id] : [],
+      total_available: availability?.total_available ?? null,
+      sufficient:
+        availability != null
+          ? availability.total_available >= qty
+          : partId
+            ? false
+            : null,
+      available_by_warehouse: availability?.available_by_warehouse ?? [],
+    })
+  }
+
+  return [...map.values()].sort((a, b) => {
+    const nameCmp = a.name.localeCompare(b.name, "es")
+    if (nameCmp !== 0) return nameCmp
+    return a.part_number.localeCompare(b.part_number, "es")
+  })
+}
+
+export function recomputeKitSufficiency(lines: ConsolidatedKitLine[]): ConsolidatedKitLine[] {
+  return lines.map((line) => {
+    if (!line.part_id || line.total_available == null) return line
+    return {
+      ...line,
+      sufficient: line.total_available >= line.required_quantity,
+    }
+  })
+}

--- a/lib/agenda/cotizador-orders.test.ts
+++ b/lib/agenda/cotizador-orders.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { flattenCotizadorOrders, isPumpProductType } from "./cotizador-orders"
+import {
+  consolidateKitLines,
+  extractPartsFromWorkOrder,
+} from "./aggregate-daily-kit"
+
+test("isPumpProductType detects pump/bombeo lines", () => {
+  assert.equal(isPumpProductType("Bombeo 42m"), true)
+  assert.equal(isPumpProductType("pump service"), true)
+  assert.equal(isPumpProductType("Concreto FC=250"), false)
+  assert.equal(isPumpProductType(null), false)
+})
+
+test("flattenCotizadorOrders excludes pump-only orders and pump lines by default", () => {
+  const rows = flattenCotizadorOrders([
+    {
+      id: "o1",
+      order_number: "100",
+      delivery_date: "2026-06-16",
+      plant_id: "p1",
+      order_status: "created",
+      order_items: [{ product_type: "Bombeo", volume: 30 }],
+    },
+    {
+      id: "o2",
+      order_number: "101",
+      delivery_date: "2026-06-16",
+      plant_id: "p1",
+      order_status: "validated",
+      order_items: [
+        { product_type: "Concreto FC=250", volume: 12 },
+        { product_type: "Bombeo", volume: 12 },
+      ],
+    },
+  ])
+
+  assert.equal(rows.length, 1)
+  assert.equal(rows[0]?.order_number, "101")
+  assert.equal(rows[0]?.product_type, "Concreto FC=250")
+  assert.equal(rows[0]?.is_pump_only, false)
+})
+
+test("flattenCotizadorOrders can include pump lines when requested", () => {
+  const rows = flattenCotizadorOrders(
+    [
+      {
+        id: "o2",
+        order_number: "101",
+        delivery_date: "2026-06-16",
+        plant_id: "p1",
+        order_status: "validated",
+        order_items: [
+          { product_type: "Concreto FC=250", volume: 12 },
+          { product_type: "Bombeo", volume: 12 },
+        ],
+      },
+    ],
+    { includePumpLines: true },
+  )
+
+  assert.equal(rows.length, 2)
+  assert.equal(rows.some((r) => r.is_pump_only), true)
+})
+
+test("extractPartsFromWorkOrder merges required_parts and task parts", () => {
+  const lines = extractPartsFromWorkOrder({
+    id: "wo1",
+    order_id: "OT-1",
+    asset_id: "a1",
+    required_parts: [{ part_id: "p1", name: "Filtro", part_number: "F-1", quantity: 2 }],
+    required_tasks: [
+      {
+        parts: [{ part_id: "p2", name: "Aceite", part_number: "A-1", quantity: 4 }],
+      },
+    ],
+  })
+
+  assert.equal(lines.length, 2)
+  assert.deepEqual(
+    lines.map((l) => l.part_id).sort(),
+    ["p1", "p2"],
+  )
+})
+
+test("consolidateKitLines sums quantities for the same part", () => {
+  const kit = consolidateKitLines(
+    [
+      { part_id: "p1", name: "Filtro", part_number: "F-1", quantity: 2 },
+      { part_id: "p1", name: "Filtro", part_number: "F-1", quantity: 3 },
+    ],
+    new Map([
+      [
+        "p1",
+        {
+          part_id: "p1",
+          part_number: "F-1",
+          part_name: "Filtro",
+          required_quantity: 5,
+          total_available: 10,
+          sufficient: true,
+          available_by_warehouse: [],
+        },
+      ],
+    ]),
+  )
+
+  assert.equal(kit.length, 1)
+  assert.equal(kit[0]?.required_quantity, 5)
+  assert.equal(kit[0]?.sufficient, true)
+})

--- a/lib/agenda/cotizador-orders.ts
+++ b/lib/agenda/cotizador-orders.ts
@@ -1,0 +1,97 @@
+const PUMP_PRODUCT_PATTERN = /pump|bombeo|bomba/i
+
+export type CotizadorOrderItemRow = {
+  order_id: string
+  order_number: string
+  delivery_date: string
+  delivery_time: string | null
+  construction_site: string | null
+  client_name: string | null
+  plant_id: string
+  plant_name: string | null
+  product_type: string | null
+  volume: number | null
+  concrete_volume_delivered: number | null
+  order_status: string
+  is_pump_only: boolean
+}
+
+type RawOrderItem = {
+  product_type?: string | null
+  volume?: number | null
+  concrete_volume_delivered?: number | null
+}
+
+type RawOrder = {
+  id: string
+  order_number: string
+  delivery_date: string
+  delivery_time?: string | null
+  construction_site?: string | null
+  plant_id: string
+  order_status: string
+  plant?: { id?: string; name?: string | null } | null
+  client?: { name?: string | null } | null
+  order_items?: RawOrderItem[] | null
+}
+
+export function isPumpProductType(productType: string | null | undefined): boolean {
+  if (!productType) return false
+  return PUMP_PRODUCT_PATTERN.test(productType)
+}
+
+function toNumber(value: unknown): number | null {
+  if (value == null || value === "") return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Flattens Cotizador orders into line rows. Pump-only lines are flagged;
+ * orders whose items are exclusively pump service are excluded.
+ */
+export function flattenCotizadorOrders(
+  orders: RawOrder[],
+  options?: { includePumpLines?: boolean },
+): CotizadorOrderItemRow[] {
+  const includePumpLines = options?.includePumpLines ?? false
+  const rows: CotizadorOrderItemRow[] = []
+
+  for (const order of orders) {
+    const items = order.order_items ?? []
+    if (items.length === 0) continue
+
+    const pumpFlags = items.map((item) => isPumpProductType(item.product_type))
+    const isOrderPumpOnly = pumpFlags.every(Boolean)
+    if (isOrderPumpOnly) continue
+
+    for (const [idx, item] of items.entries()) {
+      const isPump = pumpFlags[idx] ?? false
+      if (isPump && !includePumpLines) continue
+
+      rows.push({
+        order_id: order.id,
+        order_number: order.order_number,
+        delivery_date: order.delivery_date,
+        delivery_time: order.delivery_time ?? null,
+        construction_site: order.construction_site ?? null,
+        client_name: order.client?.name ?? null,
+        plant_id: order.plant_id,
+        plant_name: order.plant?.name ?? null,
+        product_type: item.product_type ?? null,
+        volume: toNumber(item.volume),
+        concrete_volume_delivered: toNumber(item.concrete_volume_delivered),
+        order_status: order.order_status,
+        is_pump_only: isPump,
+      })
+    }
+  }
+
+  return rows.sort((a, b) => {
+    const dateCmp = a.delivery_date.localeCompare(b.delivery_date)
+    if (dateCmp !== 0) return dateCmp
+    const timeCmp = (a.delivery_time ?? "").localeCompare(b.delivery_time ?? "")
+    if (timeCmp !== 0) return timeCmp
+    return a.order_number.localeCompare(b.order_number)
+  })
+}

--- a/lib/agenda/cotizador-plant-map.ts
+++ b/lib/agenda/cotizador-plant-map.ts
@@ -1,0 +1,56 @@
+import { createClient as createSupabaseClient, type SupabaseClient } from "@supabase/supabase-js"
+
+export type CotizadorPlantMaps = {
+  maintenanceToCotizador: Map<string, string>
+  cotizadorToMaintenance: Map<string, string>
+}
+
+/**
+ * Maps Cotizador plant UUIDs ↔ MantenPro `plants.id` via shared `code`.
+ */
+export async function buildCotizadorPlantMaps(
+  maintenanceSupabase: SupabaseClient,
+): Promise<CotizadorPlantMaps> {
+  const maintenanceToCotizador = new Map<string, string>()
+  const cotizadorToMaintenance = new Map<string, string>()
+
+  const { data: plants } = await maintenanceSupabase.from("plants").select("id, code")
+  const codeToMaintenanceId = new Map<string, string>()
+  for (const p of plants ?? []) {
+    if (p.code) codeToMaintenanceId.set(p.code, p.id)
+  }
+
+  const url = process.env.COTIZADOR_SUPABASE_URL
+  const key = process.env.COTIZADOR_SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    return { maintenanceToCotizador, cotizadorToMaintenance }
+  }
+
+  const cotizador = createSupabaseClient(url, key, { auth: { persistSession: false } })
+  const { data: cotPlants } = await cotizador.from("plants").select("id, code")
+  for (const cp of cotPlants ?? []) {
+    const mid = cp.code ? codeToMaintenanceId.get(cp.code) : undefined
+    if (mid) {
+      maintenanceToCotizador.set(mid, cp.id)
+      cotizadorToMaintenance.set(cp.id, mid)
+    }
+  }
+
+  return { maintenanceToCotizador, cotizadorToMaintenance }
+}
+
+export function resolveCotizadorPlantIds(
+  plantIdsParam: string | null,
+  maps: CotizadorPlantMaps,
+): string[] | null {
+  if (!plantIdsParam?.trim()) return null
+  const ids = plantIdsParam.split(",").map((s) => s.trim()).filter(Boolean)
+  if (ids.length === 0) return null
+
+  return ids.map((id) => {
+    if (maps.maintenanceToCotizador.has(id)) {
+      return maps.maintenanceToCotizador.get(id)!
+    }
+    return id
+  })
+}

--- a/lib/agenda/schedule-status.test.ts
+++ b/lib/agenda/schedule-status.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { AGENDA_ACTIVE_STATUSES } from "./agenda-utils"
+import { WorkOrderStatus } from "@/types"
+
+const SCHEDULABLE_STATUSES = new Set<string>(AGENDA_ACTIVE_STATUSES)
+
+test("AGENDA_ACTIVE_STATUSES includes mechanic execution statuses", () => {
+  assert.ok(SCHEDULABLE_STATUSES.has("En ejecución"))
+  assert.ok(SCHEDULABLE_STATUSES.has("En Progreso"))
+  assert.ok(SCHEDULABLE_STATUSES.has(WorkOrderStatus.Programmed))
+})
+
+test("schedule PATCH rejects completion statuses", () => {
+  assert.equal(SCHEDULABLE_STATUSES.has(WorkOrderStatus.Completed), false)
+  assert.equal(SCHEDULABLE_STATUSES.has("Completado"), false)
+  assert.equal(SCHEDULABLE_STATUSES.has("Cancelado"), false)
+})

--- a/lib/diesel-cuenta-litros-gaps.test.ts
+++ b/lib/diesel-cuenta-litros-gaps.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict"
 import {
   buildCuentaLitrosGaps,
   buildGapNarrative,
+  CUENTA_LITROS_GAP_AUDIT_FROM,
   formatTimeWindow,
   getSignificantGaps,
   indexGapsByTransactionId,
@@ -146,6 +147,69 @@ test("buildCuentaLitrosGaps excludes transfers and adjustments from registered s
   assert.equal(gaps[0]!.meter_delta, 60)
   assert.equal(gaps[0]!.gap_liters, 50)
   assert.equal(gaps[0]!.gap_type, "unregistered_dispense")
+})
+
+test("buildCuentaLitrosGaps excludes pre-April 2026 transactions from anchors and intervals", () => {
+  const transactions = [
+    tx({
+      id: "pre",
+      transaction_id: "TX-PRE",
+      quantity_liters: 80,
+      cuenta_litros: 100,
+      transaction_date: "2026-03-15T18:00:00.000Z",
+    }),
+    tx({
+      id: "apr",
+      transaction_id: "TX-APR",
+      quantity_liters: 50,
+      cuenta_litros: 200,
+      transaction_date: "2026-04-15T18:00:00.000Z",
+    }),
+    tx({
+      id: "jun",
+      transaction_id: "TX-JUN",
+      quantity_liters: 30,
+      cuenta_litros: 300,
+      transaction_date: "2026-06-15T18:00:00.000Z",
+    }),
+  ]
+
+  const gaps = buildCuentaLitrosGaps(transactions, {
+    warehouse_id: WAREHOUSE_ID,
+    has_cuenta_litros: true,
+    audit_from: CUENTA_LITROS_GAP_AUDIT_FROM,
+  })
+
+  assert.equal(gaps.length, 1)
+  assert.equal(gaps[0]!.prev_anchor.tx_id, "apr")
+  assert.equal(gaps[0]!.curr_anchor.tx_id, "jun")
+  assert.deepEqual(gaps[0]!.transaction_ids_in_interval, ["jun"])
+})
+
+test("buildCuentaLitrosGaps returns empty when only pre-April anchors exist", () => {
+  const transactions = [
+    tx({
+      id: "pre-a",
+      transaction_id: "TX-PRE-A",
+      quantity_liters: 50,
+      cuenta_litros: 100,
+      transaction_date: "2026-02-01T18:00:00.000Z",
+    }),
+    tx({
+      id: "pre-b",
+      transaction_id: "TX-PRE-B",
+      quantity_liters: 40,
+      cuenta_litros: 200,
+      transaction_date: "2026-03-20T18:00:00.000Z",
+    }),
+  ]
+
+  const gaps = buildCuentaLitrosGaps(transactions, {
+    warehouse_id: WAREHOUSE_ID,
+    has_cuenta_litros: true,
+  })
+
+  assert.deepEqual(gaps, [])
 })
 
 test("buildCuentaLitrosGaps returns empty for warehouse without meter", () => {

--- a/lib/diesel-cuenta-litros-gaps.ts
+++ b/lib/diesel-cuenta-litros-gaps.ts
@@ -57,9 +57,29 @@ export type BuildCuentaLitrosGapsOptions = {
   warehouse_id: string
   has_cuenta_litros: boolean
   tolerance_liters?: number
+  /** Local calendar date (YYYY-MM-DD, GMT-6) — only txs on/after this date are considered */
+  audit_from?: string
 }
 
+export const CUENTA_LITROS_GAP_AUDIT_FROM = "2026-04-01"
+
 const DEFAULT_TOLERANCE_LITERS = 2
+
+/** UTC timestamp → local YYYY-MM-DD (GMT-6), matching warehouse page toLocalYmd */
+function toLocalYmd(utcTimestamp: string): string {
+  if (!utcTimestamp) return ""
+  const utcDate = new Date(utcTimestamp)
+  const localTimeMs = utcDate.getTime() - 6 * 60 * 60 * 1000
+  const localDate = new Date(localTimeMs)
+  const year = localDate.getUTCFullYear()
+  const month = String(localDate.getUTCMonth() + 1).padStart(2, "0")
+  const day = String(localDate.getUTCDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function isOnOrAfterAuditFrom(transactionDate: string, auditFromYmd: string): boolean {
+  return toLocalYmd(transactionDate) >= auditFromYmd
+}
 
 function assetLabel(tx: GapTransactionInput): string | null {
   return tx.asset_name ?? tx.asset_id ?? tx.exception_asset_name ?? null
@@ -189,7 +209,10 @@ export function buildCuentaLitrosGaps(
   if (!options.has_cuenta_litros) return []
 
   const tolerance = options.tolerance_liters ?? DEFAULT_TOLERANCE_LITERS
-  const sorted = [...transactions].sort(compareTransactions)
+  const auditFromYmd = options.audit_from ?? CUENTA_LITROS_GAP_AUDIT_FROM
+  const sorted = [...transactions]
+    .filter((tx) => isOnOrAfterAuditFrom(tx.transaction_date, auditFromYmd))
+    .sort(compareTransactions)
   const anchors = sorted.filter((tx) => tx.cuenta_litros != null)
 
   if (anchors.length < 2) return []

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "verify:kpi-rollup": "npx tsx scripts/verify-kpi-rollup-consistency.ts",
     "verify:asset-meter-view": "npx tsx scripts/verify-asset-meter-view-parity.ts",
     "verify:merged-hours-view": "npx tsx scripts/verify-merged-hours-from-view.ts",
-    "test:unit": "npx tsx --test lib/utils/cyclic-maintenance.test.ts lib/maintenance/due-engine.test.ts lib/maintenance/issue-theme-taxonomy.test.ts lib/incidents/normalize-issue-core-item.test.ts lib/incidents/incident-routing.test.ts lib/incidents/incident-routing-learning.test.ts lib/incidents/incident-routing-departments.test.ts lib/reports/nomina-concept-classifier.test.ts lib/diesel-cuenta-litros-gaps.test.ts"
+    "test:unit": "npx tsx --test lib/utils/cyclic-maintenance.test.ts lib/maintenance/due-engine.test.ts lib/maintenance/issue-theme-taxonomy.test.ts lib/incidents/normalize-issue-core-item.test.ts lib/incidents/incident-routing.test.ts lib/incidents/incident-routing-learning.test.ts lib/incidents/incident-routing-departments.test.ts lib/reports/nomina-concept-classifier.test.ts lib/agenda/cotizador-orders.test.ts lib/diesel-cuenta-litros-gaps.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "verify:kpi-rollup": "npx tsx scripts/verify-kpi-rollup-consistency.ts",
     "verify:asset-meter-view": "npx tsx scripts/verify-asset-meter-view-parity.ts",
     "verify:merged-hours-view": "npx tsx scripts/verify-merged-hours-from-view.ts",
-    "test:unit": "npx tsx --test lib/utils/cyclic-maintenance.test.ts lib/maintenance/due-engine.test.ts lib/maintenance/issue-theme-taxonomy.test.ts lib/incidents/normalize-issue-core-item.test.ts lib/incidents/incident-routing.test.ts lib/incidents/incident-routing-learning.test.ts lib/incidents/incident-routing-departments.test.ts lib/reports/nomina-concept-classifier.test.ts lib/agenda/cotizador-orders.test.ts lib/diesel-cuenta-litros-gaps.test.ts"
+    "test:unit": "npx tsx --test lib/utils/cyclic-maintenance.test.ts lib/maintenance/due-engine.test.ts lib/maintenance/issue-theme-taxonomy.test.ts lib/incidents/normalize-issue-core-item.test.ts lib/incidents/incident-routing.test.ts lib/incidents/incident-routing-learning.test.ts lib/incidents/incident-routing-departments.test.ts lib/reports/nomina-concept-classifier.test.ts lib/agenda/cotizador-orders.test.ts lib/agenda/aggregate-daily-kit.test.ts lib/agenda/schedule-status.test.ts lib/agenda/agenda-auth.test.ts lib/diesel-cuenta-litros-gaps.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/types/index.ts
+++ b/types/index.ts
@@ -247,6 +247,10 @@ export enum WorkOrderStatus {
   Pending = 'Pendiente',
   Programmed = 'Programada',
   WaitingParts = 'Esperando repuestos',
+  /** Legacy DB value used by mechanic quick-start flow */
+  InExecution = 'En ejecución',
+  /** Legacy DB value; prefer InExecution for new writes */
+  InProgressLegacy = 'En Progreso',
   Completed = 'Completada'
 }
 


### PR DESCRIPTION
## Summary

- **Agenda Planning v2:** Cotizador orders API, daily-kit aggregation API, day detail panel on the weekly board, and design spec under `docs/superpowers/specs/`.
- **Navigation & workflow:** Sidebar links to agenda/hoja, `PlanWorkOrderDialog`, OT list planning filters, schedule/status APIs, mechanic start/complete on work sheet and dashboard.
- **Quick completion:** `MechanicCompleteDialog` supports tasks, parts, meter readings, and photos when closing an OT from the field.
- **Procurement via PO:** `PoProcurementNavCard` on compras flows; removed orphan sidebar CFDI/CxP shortcuts in favor of PO-scoped navigation; drawer/CxP view tweaks.
- **Auth:** `GET /api/incidents/routed` now validates session before returning data.
- **Diesel (mixed):** Cuenta-litros gap audit window from April 2026, warehouse page wiring, and unit tests — bundled in this branch for the same session; review separately if you prefer a diesel-only PR.

## Test plan

- [ ] Log in as coordinador: open `/ordenes/agenda`, select a day, confirm daily kit panel (parts + Cotizador orders when env configured).
- [ ] Plan an OT from list or agenda via `PlanWorkOrderDialog`; verify schedule persists and filters on `/ordenes` work.
- [ ] Log in as mecánico: `/ordenes/agenda/hoja` shows day OTs; start OT and complete via dialog (tasks/parts/meter/photos as applicable).
- [ ] Compras: open a PO detail and use procurement nav card; confirm comprobantes/CxP routes still work from PO context.
- [ ] `GET /api/incidents/routed` returns 401 when unauthenticated.
- [ ] `npm run test:unit` (includes `lib/agenda/cotizador-orders.test.ts` and diesel gap tests).


Made with [Cursor](https://cursor.com)